### PR TITLE
📝 Fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # La Suite Menshen: the Token Exchange server.
 
-⚠️ We are bootstraping this project. Nothing is really usable in a production context at this time.
+⚠️ We are bootstrapping this project. Nothing is really usable in a production context at this time.
 
 ## License 📝
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -13,7 +13,7 @@ roadmap: "https://github.com/orgs/suitenumerique/projects/"
 softwareType: "standalone/other"
 description:
   en:
-    shortDescription: "An OAuth 2.0 Token Exchange autorization server build with Django."
+    shortDescription: "An OAuth 2.0 Token Exchange authorization server build with Django."
   fr:
     shortDescription: "Un serveur d'authorisation pour (OAuth 2.0) Token Exchange propulsé par Django."
 legal:


### PR DESCRIPTION
## Summary
- Fix 2 typos in documentation

## Details
- README.md: bootstraping → bootstrapping
- publiccode.yml: autorization → authorization

## Test plan
- [ ] Verify changes are correct