### PR TITLE
Move exchanged token introspection logic to a service

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -135,7 +135,7 @@ jobs:
       OIDC_OP_INTROSPECTION_ENDPOINT: "http://fake.local/realms/menshen/protocol/openid-connect/token/introspect"
       OIDC_OP_JWKS_ENDPOINT: /endpoint-for-test-purpose-only
       OIDC_OP_URL: "http://fake.local"
-      OIDC_RS_CLIENT_ID: client_id
+      OIDC_RS_CLIENT_ID: menshen
       OIDC_RS_CLIENT_SECRET: client_secret
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/src/backend/token_exchange/enums.py
+++ b/src/backend/token_exchange/enums.py
@@ -24,6 +24,16 @@ class TokenExchangeResponseTokenType(StrEnum):
     NA = "N_A"
 
 
+class TokenExchangeTokenTypeHint(StrEnum):
+    """Token type hint used for token introspection (RFC 7662) and revocation (RFC 7009)."""
+
+    ACCESS_TOKEN = "access_token"  # noqa: S105
+    REFRESH_TOKEN = "refresh_token"  # noqa: S105
+
+    # Extension
+    JWT = "jwt"
+
+
 #
 # Dynamic enums depending on project settings
 #

--- a/src/backend/token_exchange/exceptions.py
+++ b/src/backend/token_exchange/exceptions.py
@@ -61,3 +61,7 @@ class TokenExchangeInvalidActionError(APIException):
     status_code = 403
     default_detail = "Invalid action."
     default_code = "invalid_action"
+
+
+class ExchangedTokenInstrospectionError(TokenExchangeError):
+    """Exception raised when exchanged token introspection failed."""

--- a/src/backend/token_exchange/factories.py
+++ b/src/backend/token_exchange/factories.py
@@ -3,7 +3,12 @@
 from datetime import UTC
 
 import factory.fuzzy
+from django.conf import settings
 from faker import Faker
+
+from token_exchange.enums import AllowedRequestedTokenTypeEnum
+from token_exchange.services.token import TokenGenerator
+from token_exchange.structs import MenshenJWTGrantClaim
 
 from . import models
 
@@ -37,6 +42,37 @@ class ExpiredExchangedTokenFactory(ExchangedTokenFactory):
     expires_at = factory.LazyFunction(
         lambda: fake.date_time_between(start_date="-30d", end_date="-1d", tzinfo=UTC)
     )
+
+
+class JWTExchangedTokenFactory(ExchangedTokenFactory):
+    """A factory to create JWT ExchangedToken instances for testing."""
+
+    token = factory.LazyAttribute(
+        lambda o: TokenGenerator.generate_jwt(
+            sub=o.subject_sub,
+            email=o.subject_email,
+            audiences=o.audiences,
+            scope="openid target:read target:write",
+            expires_in=3600,
+            kid=settings.TOKEN_EXCHANGE_JWT_CURRENT_KID,
+            grants=[
+                MenshenJWTGrantClaim(
+                    audience_id=o.audiences[0],
+                    scope="target:read",
+                    throttle=None,
+                ),
+                MenshenJWTGrantClaim(
+                    audience_id=o.audiences[0],
+                    scope="target:write",
+                    throttle=None,
+                ),
+            ],
+        )
+    )
+    token_type = AllowedRequestedTokenTypeEnum.JWT
+    subject_sub = "ef7d37b4-080c-4df7-b0f8-3560dc7138aa"
+    subject_email = "jane.doe@example.org"
+    audiences = ["service:target"]
 
 
 class ServiceProviderFactory(factory.django.DjangoModelFactory):

--- a/src/backend/token_exchange/models.py
+++ b/src/backend/token_exchange/models.py
@@ -14,7 +14,7 @@ from django.db.models import JSONField
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from .enums import TokenTypeEnum
+from .enums import TokenExchangeTokenTypeHint, TokenTypeEnum
 from .structs import IntrospectionResponse
 
 logger = logging.getLogger(__name__)
@@ -31,6 +31,14 @@ class TokenTypeChoices(models.TextChoices):
 
     ACCESS_TOKEN = TokenTypeEnum.ACCESS_TOKEN, _("Access Token")
     JWT = TokenTypeEnum.JWT, _("JWT")
+
+
+# Mapping between token type hint and token type choices
+TOKEN_TYPE_HINT_CHOICES_MAPPING = {
+    TokenExchangeTokenTypeHint.ACCESS_TOKEN: TokenTypeChoices.ACCESS_TOKEN,
+    TokenExchangeTokenTypeHint.REFRESH_TOKEN: None,
+    TokenExchangeTokenTypeHint.JWT: TokenTypeChoices.JWT,
+}
 
 
 class BaseModel(models.Model):

--- a/src/backend/token_exchange/services/introspection.py
+++ b/src/backend/token_exchange/services/introspection.py
@@ -1,0 +1,104 @@
+"""Menshen: services:introspection for the token_exchange application."""
+
+import logging
+from functools import cached_property
+
+from token_exchange.exceptions import ExchangedTokenInstrospectionError
+from token_exchange.models import (
+    ExchangedToken,
+    ServiceProvider,
+    TokenTypeChoices,
+)
+from token_exchange.services.token import TokenGenerator
+from token_exchange.structs import IntrospectionRequest, IntrospectionResponse
+
+logger = logging.getLogger(__name__)
+
+
+class TokenExchangeIntrospectionService:
+    """
+    Token exchange introspection service.
+
+    Use this service to introspect an exchanged token.
+
+    Note that the request is supposed to be valid when submitted to this service.
+
+    """
+
+    def __init__(self, service: ServiceProvider, request: IntrospectionRequest):
+        """
+        Initialize the service.
+
+        Args:
+            service: the sources service performing the token introspection request
+            request: the token introspection request
+
+        """
+        if service is None or request is None:
+            raise ExchangedTokenInstrospectionError("Empty request or service.")
+
+        self._service: ServiceProvider = service
+        self._request: IntrospectionRequest = request
+
+    @cached_property
+    def exchanged_token(self) -> ExchangedToken:
+        """Get introspection request token from the database."""
+        try:
+            token = ExchangedToken.objects.get(token=self._request.token)
+        except ExchangedToken.DoesNotExist as exc:
+            logger.info("Introspected token not found.")
+            raise ExchangedTokenInstrospectionError("Token not found.") from exc
+
+        return token
+
+    def is_token_valid(self) -> bool:
+        """Check introspected token validity."""
+        # Stored exchanged token validity
+        try:
+            token = self.exchanged_token
+        except ExchangedTokenInstrospectionError:
+            return False  # Token not found
+
+        # Token has already expired or has been revoked
+        if not token.is_valid():
+            logger.warning(
+                "Token introspected (invalid): token_jti=%s, type=%s, kid=%s",
+                token.subject_token_jti,
+                token.token_type,
+                token.jwt_kid or "N/A",
+            )
+            return False
+
+        # Check token audiences against requesting service
+        if self._service.audience_id not in token.audiences:
+            logger.error(
+                "'%s' service tried to introspect an exchanged token that is beyond its audience",
+                self._service.audience_id,
+            )
+            return False
+
+        # JWT case
+        if token.token_type == TokenTypeChoices.JWT:
+            # JWT signature verification
+            try:
+                TokenGenerator.verify_jwt(token.token)
+            except ValueError as exc:
+                logger.warning(
+                    "Token introspected: JWT signature verification failed: %s",
+                    str(exc),
+                )
+                return False
+
+        return True
+
+    def generate_introspection_response(self) -> IntrospectionResponse:
+        """Generate token introspection response."""
+        if not self.is_token_valid():
+            return IntrospectionResponse(active=False)
+        logger.info(
+            "Token introspected (active): token_jti=%s, type=%s, kid=%s",
+            self.exchanged_token.subject_token_jti,
+            self.exchanged_token.token_type,
+            self.exchanged_token.jwt_kid or "N/A",
+        )
+        return self.exchanged_token.to_introspection_response()

--- a/src/backend/token_exchange/services/request.py
+++ b/src/backend/token_exchange/services/request.py
@@ -26,11 +26,11 @@ from ..exceptions import (
 )
 from ..models import (
     ActionScopeGrant,
-    IntrospectionResponse,
     ScopeGrant,
     TokenExchangeRule,
 )
 from ..structs import (
+    IntrospectionResponse,
     MenshenJWTGrantClaim,
     MenshenJWTGrantClaimThrottling,
     MenshenTokenExchangeResponse,

--- a/src/backend/token_exchange/structs.py
+++ b/src/backend/token_exchange/structs.py
@@ -16,6 +16,7 @@ from .enums import (
     AllowedRequestedTokenTypeEnum,
     AllowedSubjectTokenTypeEnum,
     TokenExchangeResponseTokenType,
+    TokenExchangeTokenTypeHint,
     TokenTypeEnum,
 )
 
@@ -302,7 +303,22 @@ class MenshenTokenExchangeResponse(TokenExchangeResponse):
     grants: list[MenshenJWTGrantClaim]
 
 
-class TokenRevocationRequest(msgspec.Struct, MenshenStructMixin, forbid_unknown_fields=True):
+class IntrospectionRequest(msgspec.Struct, MenshenStructMixin, forbid_unknown_fields=True):
+    """
+    Exchanged token introspection request.
+
+    Reference:
+    https://www.rfc-editor.org/info/rfc7662/#section-2.1
+    """
+
+    # When striped the token should be at least 32 characters long (opaque token)
+    token: Annotated[str, msgspec.Meta(pattern=r"^\s*\S{32,}\s*$")]
+    token_type_hint: TokenExchangeTokenTypeHint | None = None
+
+
+class ExchangedTokenRevocationRequest(
+    msgspec.Struct, MenshenStructMixin, forbid_unknown_fields=True
+):
     """
     Exchanged token revocation request.
 
@@ -312,4 +328,4 @@ class TokenRevocationRequest(msgspec.Struct, MenshenStructMixin, forbid_unknown_
 
     # When striped the token should be at least 32 characters long (opaque token)
     token: Annotated[str, msgspec.Meta(pattern=r"^\s*\S{32,}\s*$")]
-    token_type_hint: AllowedRequestedTokenTypeEnum | None = None
+    token_type_hint: TokenExchangeTokenTypeHint | None = None

--- a/src/backend/token_exchange/tests/services/test_introspection.py
+++ b/src/backend/token_exchange/tests/services/test_introspection.py
@@ -1,0 +1,222 @@
+"""Menshen: introspection service tests for the token_exchange application."""
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from token_exchange.enums import (
+    TokenExchangeTokenTypeHint,
+)
+from token_exchange.exceptions import ExchangedTokenInstrospectionError
+from token_exchange.factories import ExchangedTokenFactory, JWTExchangedTokenFactory
+from token_exchange.models import ExchangedToken, TokenTypeChoices
+from token_exchange.services.introspection import TokenExchangeIntrospectionService
+from token_exchange.services.token import TokenGenerator
+from token_exchange.structs import IntrospectionRequest, IntrospectionResponse
+
+
+@pytest.mark.parametrize(("service", "request_"), [(None, None), (None, ""), ("", None)])
+def test_introspection_service_instantiation_with_bad_args(service, request_):
+    """Test the introspection service instantiation with bad arguments."""
+    with pytest.raises(ExchangedTokenInstrospectionError, match=r"Empty request or service\."):
+        TokenExchangeIntrospectionService(service=service, request=request_)
+
+
+@pytest.mark.parametrize(
+    "token_type_hint",
+    [None, TokenExchangeTokenTypeHint.REFRESH_TOKEN, TokenExchangeTokenTypeHint.ACCESS_TOKEN],
+)
+def test_introspection_service_token_property_with_optional_type_hint(
+    target_service, token_type_hint
+):
+    """Test the introspection service token cached property with the optional token_type_hint."""
+    exchanged_token = ExchangedTokenFactory(
+        token_type=TokenTypeChoices.ACCESS_TOKEN, audiences=[target_service.audience_id]
+    )
+    request = IntrospectionRequest(
+        token=str(exchanged_token.token), token_type_hint=token_type_hint
+    )
+    introspection_service = TokenExchangeIntrospectionService(
+        service=target_service, request=request
+    )
+
+    assert isinstance(introspection_service.exchanged_token, ExchangedToken)
+    assert introspection_service.exchanged_token == exchanged_token
+
+
+def test_introspection_service_token_property_with_bad_type_hint(target_service):
+    """Test the introspection service token property with a bad token_type_hint."""
+    exchanged_token = ExchangedTokenFactory(
+        token_type=TokenTypeChoices.ACCESS_TOKEN, audiences=[target_service.audience_id]
+    )
+    request = IntrospectionRequest(
+        token=str(exchanged_token.token), token_type_hint=TokenExchangeTokenTypeHint.JWT
+    )
+    introspection_service = TokenExchangeIntrospectionService(
+        service=target_service, request=request
+    )
+
+    assert isinstance(introspection_service.exchanged_token, ExchangedToken)
+    assert introspection_service.exchanged_token == exchanged_token
+
+
+def test_introspection_service_token_property_when_token_not_found(target_service, caplog):
+    """Test the introspection service token property when the token is not found."""
+    request = IntrospectionRequest(token="foo")
+    introspection_service = TokenExchangeIntrospectionService(
+        service=target_service, request=request
+    )
+
+    with (
+        caplog.at_level(logging.INFO),
+        pytest.raises(ExchangedTokenInstrospectionError, match=r"Token not found\."),
+    ):
+        assert introspection_service.exchanged_token
+    assert not introspection_service.is_token_valid()
+    assert "Introspected token not found." in caplog.messages
+
+
+@pytest.mark.parametrize(
+    ("expires_at", "revoked_at"),
+    [
+        (datetime(2026, 1, 1, 0, 0, tzinfo=UTC), None),
+        (datetime.now(tz=UTC) + timedelta(days=30), (datetime(2026, 1, 1, 0, 0, tzinfo=UTC))),
+        (
+            datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+            datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+        ),
+    ],
+)
+def test_introspection_service_token_expired_or_revoked(
+    target_service, expires_at, revoked_at, caplog
+):
+    """Test the introspection service with an expired or revoked token."""
+    exchanged_token = ExchangedTokenFactory(
+        token_type=TokenTypeChoices.ACCESS_TOKEN,
+        audiences=[target_service.audience_id],
+        expires_at=expires_at,
+        revoked_at=revoked_at,
+    )
+    request = IntrospectionRequest(token=str(exchanged_token.token))
+    introspection_service = TokenExchangeIntrospectionService(
+        service=target_service, request=request
+    )
+    with caplog.at_level(logging.INFO):
+        assert not introspection_service.is_token_valid()
+    assert (
+        "Token introspected (invalid): "
+        f"token_jti={introspection_service.exchanged_token.subject_token_jti}, "
+        f"type={introspection_service.exchanged_token.token_type}, "
+        f"kid={introspection_service.exchanged_token.jwt_kid or 'N/A'}"
+    ) in caplog.messages
+
+
+def test_introspection_service_token_with_bad_audiences(target_service, caplog):
+    """Test the introspection service with a bad audience."""
+    exchanged_token = ExchangedTokenFactory(
+        token_type=TokenTypeChoices.ACCESS_TOKEN,
+        audiences=["service:foo"],
+    )
+    request = IntrospectionRequest(token=str(exchanged_token.token))
+    introspection_service = TokenExchangeIntrospectionService(
+        service=target_service, request=request
+    )
+    with caplog.at_level(logging.INFO):
+        assert not introspection_service.is_token_valid()
+    assert (
+        f"'{target_service.audience_id}' service tried to introspect an exchanged token "
+        "that is beyond its audience"
+    ) in caplog.messages
+
+
+def test_introspection_service_valid_access_token(target_service):
+    """Test the introspection service with a valid access token."""
+    exchanged_token = ExchangedTokenFactory(
+        token_type=TokenTypeChoices.ACCESS_TOKEN,
+        audiences=[target_service.audience_id],
+    )
+    request = IntrospectionRequest(token=str(exchanged_token.token))
+    introspection_service = TokenExchangeIntrospectionService(
+        service=target_service, request=request
+    )
+    assert introspection_service.is_token_valid()
+
+
+def test_introspection_service_valid_jwt(target_service):
+    """Test the introspection service with a valid JWT."""
+    exchanged_token = JWTExchangedTokenFactory()
+    request = IntrospectionRequest(
+        token=str(exchanged_token.token), token_type_hint=TokenExchangeTokenTypeHint.JWT
+    )
+    introspection_service = TokenExchangeIntrospectionService(
+        service=target_service, request=request
+    )
+    assert introspection_service.is_token_valid()
+
+
+def test_introspection_service_generate_response_with_invalid_jwt(target_service, settings, caplog):
+    """Test the introspection service response generation with an invalid JWT."""
+    exchanged_jwt = TokenGenerator.generate_jwt(
+        sub="ef7d37b4-080c-4df7-b0f8-3560dc7138aa",
+        email="jane.doe@example.org",
+        audiences=["service:target"],
+        scope="openid target:read target:write",
+        expires_in=3600,
+        kid=settings.TOKEN_EXCHANGE_JWT_CURRENT_KID,
+        # Grants are missing
+        grants=[],
+    )
+
+    exchanged_token = JWTExchangedTokenFactory(token=exchanged_jwt)
+    request = IntrospectionRequest(
+        token=str(exchanged_token.token), token_type_hint=TokenExchangeTokenTypeHint.JWT
+    )
+    introspection_service = TokenExchangeIntrospectionService(
+        service=target_service, request=request
+    )
+    with caplog.at_level(logging.INFO):
+        assert not introspection_service.is_token_valid()
+    assert (
+        "Token introspected: JWT signature verification failed: "
+        "Invalid JWT claims: invalid_claim: Invalid claim: 'grants'"
+    ) in caplog.messages
+
+    response = introspection_service.generate_introspection_response()
+    assert response == IntrospectionResponse(active=False)
+
+
+def test_introspection_service_generate_response_with_valid_jwt(target_service, caplog):
+    """Test the introspection service response generation with an valid JWT."""
+    now = int(datetime.now(tz=UTC).timestamp())
+    exchanged_token = JWTExchangedTokenFactory()
+    request = IntrospectionRequest(
+        token=str(exchanged_token.token), token_type_hint=TokenExchangeTokenTypeHint.JWT
+    )
+    introspection_service = TokenExchangeIntrospectionService(
+        service=target_service, request=request
+    )
+
+    with caplog.at_level(logging.INFO):
+        response = introspection_service.generate_introspection_response()
+    assert response.active
+    assert response.scope == "openid email profile"
+    assert response.sub == "ef7d37b4-080c-4df7-b0f8-3560dc7138aa"
+    assert response.email == "jane.doe@example.org"
+    assert response.username == "jane.doe@example.org"
+    assert response.token_type == "urn:ietf:params:oauth:token-type:jwt"
+    assert response.exp
+    assert response.exp > now
+    assert response.iat
+    # iat should be ~ now
+    assert response.iat >= now - 2
+    assert response.iat <= now + 2
+    assert response.aud == ["service:target"]
+    assert response.jti == exchanged_token.subject_token_jti
+    assert response.client_id == "menshen"
+    assert (
+        "Token introspected (active): "
+        f"token_jti={exchanged_token.subject_token_jti}, "
+        f"type={exchanged_token.token_type}, "
+        f"kid={exchanged_token.jwt_kid or 'N/A'}"
+    ) in caplog.messages

--- a/src/backend/token_exchange/tests/test_structs.py
+++ b/src/backend/token_exchange/tests/test_structs.py
@@ -11,16 +11,18 @@ from joserfc.jwt import ClaimsOption, JWTClaimsRegistry
 from token_exchange.enums import (
     AllowedActorTokenTypeEnum,
     TokenExchangeResponseTokenType,
+    TokenExchangeTokenTypeHint,
     TokenTypeEnum,
 )
 from token_exchange.structs import (
+    ExchangedTokenRevocationRequest,
+    IntrospectionRequest,
     MenshenJWTClaims,
     MenshenStructMixin,
     TokenExchangeJWTActClaim,
     TokenExchangeJWTClaims,
     TokenExchangeRequest,
     TokenExchangeResponse,
-    TokenRevocationRequest,
 )
 
 
@@ -98,7 +100,7 @@ def test_menshenjwtclaims_struct_default_factories():
 
 def test_menshenjwtclaims_struct_to_jwt_claims_registry():
     """Test the MenshenJWTClaims struct to_jwt_claims_registy method."""
-    # joserfc does not allow None in ClaimsOption.value, we think it's perfectly legit and thus
+    # joserfc does not allow None in ClaimsOption.value, we think it's perfectly legit & thus
     # ignore typing issues deliberately.
     assert (
         MenshenJWTClaims.to_jwt_claims_registry().options
@@ -336,35 +338,52 @@ def test_tokenexchangeresponse_struct_expires_in(settings):
         msgspec.json.decode(json.dumps(payload), type=TokenExchangeResponse)
 
 
-def test_tokenrevocationrequest_struct_decoding():
-    """Test the TokenRevocationRequest struct decoding."""
+@pytest.mark.parametrize(
+    "token_request_struc",
+    [
+        IntrospectionRequest,
+        ExchangedTokenRevocationRequest,
+    ],
+)
+@pytest.mark.parametrize(
+    "token_type_hint",
+    [
+        TokenExchangeTokenTypeHint.ACCESS_TOKEN,
+        TokenExchangeTokenTypeHint.REFRESH_TOKEN,
+        TokenExchangeTokenTypeHint.JWT,
+    ],
+)
+def test_token_request_struct_decoding(token_request_struc, token_type_hint):
+    """Test IntrospectionRequest & ExchangedTokenRevocationRequeststruct decoding."""
     token = secrets.token_urlsafe(32)
     payload = {
         "token": token,
     }
 
-    token_revocation_request = msgspec.json.decode(json.dumps(payload), type=TokenRevocationRequest)
-    assert token_revocation_request.token == token
-    assert token_revocation_request.token_type_hint is None
+    token_request = msgspec.json.decode(json.dumps(payload), type=token_request_struc)
+    assert token_request.token == token
+    assert token_request.token_type_hint is None
 
     # With a token_type_hint
-    payload.update({"token_type_hint": TokenTypeEnum.ACCESS_TOKEN})
-    token_revocation_request = msgspec.json.decode(json.dumps(payload), type=TokenRevocationRequest)
-    assert token_revocation_request.token == token
-    assert token_revocation_request.token_type_hint == TokenTypeEnum.ACCESS_TOKEN
+    payload.update({"token_type_hint": token_type_hint})
+    token_request = msgspec.json.decode(json.dumps(payload), type=token_request_struc)
+    assert token_request.token == token
+    assert token_request.token_type_hint == token_type_hint
 
 
 @pytest.mark.parametrize(
     "token_type_hint",
+    ["id_token", "saml1", "saml2", "fake_type"],
+)
+@pytest.mark.parametrize(
+    "token_request_struc",
     [
-        TokenTypeEnum.REFRESH_TOKEN,
-        TokenTypeEnum.ID_TOKEN,
-        TokenTypeEnum.SAML1,
-        TokenTypeEnum.SAML2,
+        IntrospectionRequest,
+        ExchangedTokenRevocationRequest,
     ],
 )
-def test_tokenrevocationrequest_struct_allowed_token_type_hint(token_type_hint):
-    """Test the TokenRevocationRequest struct allowed token type hint."""
+def test_token_request_struct_with_invalid_token_type_hint(token_type_hint, token_request_struc):
+    """Test ExchangedToken*Request structs with invalid token type hint."""
     payload = {
         "token": secrets.token_urlsafe(32),
         "token_type_hint": token_type_hint,
@@ -372,9 +391,9 @@ def test_tokenrevocationrequest_struct_allowed_token_type_hint(token_type_hint):
 
     with pytest.raises(
         msgspec.ValidationError,
-        match="Invalid enum value 'urn:ietf:params:oauth:token-type:",
+        match=f"Invalid enum value '{token_type_hint}'",
     ):
-        msgspec.json.decode(json.dumps(payload), type=TokenRevocationRequest)
+        msgspec.json.decode(json.dumps(payload), type=token_request_struc)
 
 
 @pytest.mark.parametrize(
@@ -385,8 +404,15 @@ def test_tokenrevocationrequest_struct_allowed_token_type_hint(token_type_hint):
         " " * 14 + "fake" + " " * 14,  # 32 characters but padded with spaces
     ],
 )
-def test_tokenrevocationrequest_struct_invalid_token(token):
-    """Test the TokenRevocationRequest struct with an invalid token."""
+@pytest.mark.parametrize(
+    "token_request_struc",
+    [
+        IntrospectionRequest,
+        ExchangedTokenRevocationRequest,
+    ],
+)
+def test_token_request_struct_invalid_token(token, token_request_struc):
+    """Test ExchangedToken*Request structs with an invalid token."""
     payload = {
         "token": token,
     }
@@ -394,15 +420,22 @@ def test_tokenrevocationrequest_struct_invalid_token(token):
     with pytest.raises(
         msgspec.ValidationError, match=r"Expected `str` matching regex .* at `\$.token`"
     ):
-        msgspec.json.decode(json.dumps(payload), type=TokenRevocationRequest)
+        msgspec.json.decode(json.dumps(payload), type=token_request_struc)
 
 
-def test_tokenrevocationrequest_struct_valid_access_token():
-    """Test the TokenRevocationRequest struct with a valid access token."""
+@pytest.mark.parametrize(
+    "token_request_struc",
+    [
+        IntrospectionRequest,
+        ExchangedTokenRevocationRequest,
+    ],
+)
+def test_token_request_struct_valid_access_token(token_request_struc):
+    """Test ExchangedToken*Request structs with a valid access token."""
     payload = {
         "token": "f4k3" * 8,  # 32 characters
     }
 
-    token_revokation_request = msgspec.json.decode(json.dumps(payload), type=TokenRevocationRequest)
-    assert token_revokation_request.token == "f4k3" * 8
-    assert token_revokation_request.token_type_hint is None
+    token_request = msgspec.json.decode(json.dumps(payload), type=token_request_struc)
+    assert token_request.token == "f4k3" * 8
+    assert token_request.token_type_hint is None

--- a/src/backend/token_exchange/tests/test_views.py
+++ b/src/backend/token_exchange/tests/test_views.py
@@ -306,7 +306,7 @@ def test_introspect_view_with_unknown_token(target_api_client, caplog):
         )
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"active": False}
-    assert "Token introspected: token not found, active=False" in caplog.messages
+    assert "Introspected token not found." in caplog.messages
 
 
 @pytest.mark.django_db
@@ -322,14 +322,20 @@ def test_introspect_view_with_unknown_token(target_api_client, caplog):
         (datetime.now(tz=UTC) + timedelta(hours=1), datetime.now(tz=UTC) - timedelta(minutes=1)),
     ],
 )
-def test_introspect_view_invalid_token(
-    target_api_client, caplog, token_type, expires_at, revoked_at
+def test_introspect_view_invalid_token(  # noqa: PLR0913
+    target_api_client,
+    target_service,
+    caplog,
+    token_type,
+    expires_at,
+    revoked_at,
 ):
     """Test the TokenIntrospectView with an invalid exchange token (expired or revoked)."""
     exchanged_token = ExchangedTokenFactory(
         expires_at=expires_at,
         revoked_at=revoked_at,
         token_type=token_type,
+        audiences=[target_service.audience_id],
     )
     with caplog.at_level(logging.INFO):
         response = target_api_client.post(
@@ -340,15 +346,17 @@ def test_introspect_view_invalid_token(
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"active": False}
     assert (
-        f"Token introspected: token_jti={exchanged_token.subject_token_jti}, "
-        f"active=False, format={token_type} [invalid]"
+        f"Token introspected (invalid): token_jti={exchanged_token.subject_token_jti}, "
+        f"type={token_type}, kid=N/A"
     ) in caplog.messages
 
 
 @pytest.mark.django_db
-def test_introspect_view_invalid_jwt_signature(target_api_client, caplog):
+def test_introspect_view_invalid_jwt_signature(target_api_client, target_service, caplog):
     """Test the TokenIntrospectView with a badly signed JWT exchange token."""
-    exchanged_token = ExchangedTokenFactory(token_type=TokenTypeChoices.JWT)
+    exchanged_token = ExchangedTokenFactory(
+        token_type=TokenTypeChoices.JWT, audiences=[target_service.audience_id]
+    )
     with (
         caplog.at_level(logging.INFO),
         mock.patch.object(TokenGenerator, "verify_jwt", side_effect=ValueError("wrong signature")),
@@ -366,9 +374,75 @@ def test_introspect_view_invalid_jwt_signature(target_api_client, caplog):
 
 
 @pytest.mark.django_db
-def test_introspect_view_introspection(target_api_client, caplog):
+def test_introspect_view_invalid_audience(target_api_client, caplog):
+    """Test the TokenIntrospectView with an invalid audience from requesting service."""
+    exchanged_token = ExchangedTokenFactory(
+        token_type=TokenTypeChoices.JWT, audiences=["service:foo"]
+    )
+    with caplog.at_level(logging.INFO):
+        response = target_api_client.post(
+            "/auth/token/introspect/",
+            {"token": exchanged_token.token},
+            content_type="application/json",
+        )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"active": False}
+    assert (
+        "'service:target' service tried to introspect an "
+        "exchanged token that is beyond its audience"
+    ) in caplog.messages
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("token_type_hint", ["bogus", "refresh"])
+def test_introspect_view_introspection_with_wrong_token_type_hint(
+    target_api_client, target_service, token_type_hint, caplog
+):
+    """Test the TokenIntrospectView instrospection with a falsy token type hint."""
+    exchanged_token = ExchangedTokenFactory(
+        token_type=TokenTypeChoices.ACCESS_TOKEN, audiences=[target_service.audience_id]
+    )
+    with caplog.at_level(logging.INFO):
+        response = target_api_client.post(
+            "/auth/token/introspect/",
+            {"token": exchanged_token.token, "token_type_hint": token_type_hint},
+            content_type="application/json",
+        )
+    assert response.status_code == status.HTTP_200_OK
+    introspected_token = response.json()
+    assert not introspected_token["active"]
+
+
+@pytest.mark.django_db
+def test_introspect_view_introspection_with_token_type_hint(
+    target_api_client, target_service, caplog
+):
     """Test the TokenIntrospectView instrospection."""
-    exchanged_token = ExchangedTokenFactory(token_type=TokenTypeChoices.ACCESS_TOKEN)
+    exchanged_token = ExchangedTokenFactory(
+        token_type=TokenTypeChoices.ACCESS_TOKEN, audiences=[target_service.audience_id]
+    )
+    with caplog.at_level(logging.INFO):
+        response = target_api_client.post(
+            "/auth/token/introspect/",
+            {"token": exchanged_token.token, "token_type_hint": "access_token"},
+            content_type="application/json",
+        )
+    assert response.status_code == status.HTTP_200_OK
+    introspected_token = response.json()
+    assert introspected_token["active"]
+    assert (
+        f"Token introspected (active): token_jti={exchanged_token.subject_token_jti}, "
+        f"type={exchanged_token.token_type}, kid={exchanged_token.jwt_kid or 'N/A'}"
+        in caplog.messages
+    )
+
+
+@pytest.mark.django_db
+def test_introspect_view_introspection(target_api_client, target_service, caplog):
+    """Test the TokenIntrospectView instrospection."""
+    exchanged_token = ExchangedTokenFactory(
+        token_type=TokenTypeChoices.ACCESS_TOKEN, audiences=[target_service.audience_id]
+    )
     with caplog.at_level(logging.INFO):
         response = target_api_client.post(
             "/auth/token/introspect/",
@@ -377,8 +451,8 @@ def test_introspect_view_introspection(target_api_client, caplog):
         )
     assert response.status_code == status.HTTP_200_OK
     assert (
-        f"Token introspected: token_jti={exchanged_token.subject_token_jti}, active=True, "
-        f"format={exchanged_token.token_type}, kid={exchanged_token.jwt_kid or 'N/A'}"
+        f"Token introspected (active): token_jti={exchanged_token.subject_token_jti}, "
+        f"type={exchanged_token.token_type}, kid={exchanged_token.jwt_kid or 'N/A'}"
         in caplog.messages
     )
     introspected_token = response.json()

--- a/src/backend/token_exchange/views.py
+++ b/src/backend/token_exchange/views.py
@@ -14,14 +14,17 @@ from rest_framework.views import APIView
 from .authentication import ServiceProviderBasicAuthentication
 from .models import (
     ExchangedToken,
-    IntrospectionResponse,
-    TokenTypeChoices,
 )
 from .permissions import IsServiceProviderAuthenticated
 from .serializers import TokenRevocationSerializer
+from .services.introspection import TokenExchangeIntrospectionService
 from .services.request import TokenExchangeRequestService
-from .services.token import TokenGenerator
-from .structs import MenshenTokenExchangeResponse, TokenExchangeRequest
+from .structs import (
+    IntrospectionRequest,
+    IntrospectionResponse,
+    MenshenTokenExchangeResponse,
+    TokenExchangeRequest,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -139,63 +142,37 @@ class TokenIntrospectionView(APIView):
     authentication_classes = [ServiceProviderBasicAuthentication]
     permission_classes = [IsServiceProviderAuthenticated]
 
-    @staticmethod
-    def _to_response(
-        introspection_response: IntrospectionResponse, status: int = status.HTTP_200_OK
-    ) -> Response:
-        """Serialize the introspection response to a proper Django HTTP response."""
-        return Response(introspection_response.to_dict(), status=status)
-
     def post(self, request):
         """
         Handle token introspection requests.
 
         Accepts a token and returns its validity and metadata.
         """
-        # Default response payload
-        inactive_introspection_response = IntrospectionResponse(active=False)
+        # Retrieve authenticated service provider
+        source_service = request.user
 
-        # Get token from request (form-encoded or JSON)
-        token = request.data.get("token")
-        if not token:
-            return self._to_response(inactive_introspection_response)
-
-        # Look up the token
+        # !!!!!!!!!!!!
+        # EXPERIMENTAL
+        # !!!!!!!!!!!!
+        #
+        # This is a temporary parsing solution preparing the django-bolt migration
         try:
-            exchanged_token = ExchangedToken.objects.get(token=token)
-        except ExchangedToken.DoesNotExist:
-            logger.info("Token introspected: token not found, active=False")
-            return self._to_response(inactive_introspection_response)
-
-        # Check if valid
-        if not exchanged_token.is_valid():
-            logger.info(
-                "Token introspected: token_jti=%s, active=False, format=%s [invalid]",
-                exchanged_token.subject_token_jti,
-                exchanged_token.token_type,
+            token_introspection_request = msgspec.json.decode(
+                request.body, type=IntrospectionRequest
             )
-            return self._to_response(inactive_introspection_response)
-
-        # For JWT tokens, verify signature
-        if exchanged_token.token_type == TokenTypeChoices.JWT:
-            try:
-                TokenGenerator.verify_jwt(token)
-            except ValueError as exc:
-                logger.warning(
-                    "Token introspected: JWT signature verification failed: %s",
-                    str(exc),
-                )
-                return self._to_response(inactive_introspection_response)
-
-        introspection_response = exchanged_token.to_introspection_response()
-        logger.info(
-            "Token introspected: token_jti=%s, active=%s, format=%s, kid=%s",
-            exchanged_token.subject_token_jti,
-            introspection_response.active,
-            exchanged_token.token_type,
-            exchanged_token.jwt_kid or "N/A",
+        except msgspec.ValidationError:
+            return Response(
+                IntrospectionResponse(active=False).to_dict(),
+                status=status.HTTP_200_OK,
+            )
+        token_exchange_introspection_service = TokenExchangeIntrospectionService(
+            service=source_service, request=token_introspection_request
         )
-        return self._to_response(introspection_response)
+        introspection_response: IntrospectionResponse = (
+            token_exchange_introspection_service.generate_introspection_response()
+        )
+
+        return Response(introspection_response.to_dict(), status=status.HTTP_200_OK)
 
 
 class TokenRevocationView(APIView):


### PR DESCRIPTION
## Purpose

To ease application maintenance and incoming refactoring, we should move the core logic to dedicated services and split the whole procedure in dedicated methods.

## Proposal

- [x] move the token exchange introspection management from the view to a dedicated service

---

Current work is a follow up (and depends on) #31
