### PR TITLE
👷(project) add Helm chart linting and publication workflows

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,28 @@
+name: Helmfile lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - src/helm/menshen/**
+
+permissions: {}
+
+jobs:
+  helmfile-lint:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/helmfile/helmfile:v1.5.2
+    steps:
+
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Helmfile lint
+      run: helmfile -e dev -f src/helm/helmfile.yaml.gotmpl lint

--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -1,0 +1,38 @@
+name: Release Chart
+run-name: Release Chart
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - src/helm/menshen/**
+
+permissions: 
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Cleanup
+        run: rm -rf ./src/helm/extra
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Publish Helm charts
+        uses: numerique-gouv/helm-gh-pages@2cf477ae49d7c70037ceb1685803f4f7bad9b981 # add-overwrite-option
+        with:
+          charts_dir: ./src/helm
+          linting: on
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose

We need to lint and push project's Helm chart to a dedicated repository to be able to deploy it.

## Proposal

- [x] lint Helm chart for every PR
- [x] publish helm chart when pushing changes

