### PR TITLE
♻️(backend) remove Enum suffix from Enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ### Changed 
 
+- Remove enums `Enum` suffix
+
 #### Dependencies
 
 - Upgrade `django-lasuite` to `0.0.27`

--- a/src/backend/token_exchange/enums.py
+++ b/src/backend/token_exchange/enums.py
@@ -5,7 +5,7 @@ from enum import StrEnum
 from django.conf import settings
 
 
-class TokenTypeEnum(StrEnum):
+class TokenType(StrEnum):
     """Token type identifier for RFC 8693."""
 
     ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token"  # noqa: S105
@@ -37,24 +37,24 @@ class TokenExchangeTokenTypeHint(StrEnum):
 #
 # Dynamic enums depending on project settings
 #
-AllowedRequestedTokenTypeEnum = StrEnum(
-    "AllowedRequestedTokenTypeEnum",
+AllowedRequestedTokenType = StrEnum(
+    "AllowedRequestedTokenType",
     {
-        TokenTypeEnum(type_).name: TokenTypeEnum(type_).value
+        TokenType(type_).name: TokenType(type_).value
         for type_ in settings.TOKEN_EXCHANGE_ALLOWED_REQUESTED_TOKEN_TYPES
     },
 )
-AllowedActorTokenTypeEnum = StrEnum(
-    "AllowedActorTokenTypeEnum",
+AllowedActorTokenType = StrEnum(
+    "AllowedActorTokenType",
     {
-        TokenTypeEnum(type_).name: TokenTypeEnum(type_).value
+        TokenType(type_).name: TokenType(type_).value
         for type_ in settings.TOKEN_EXCHANGE_ALLOWED_ACTOR_TOKEN_TYPES
     },
 )
-AllowedSubjectTokenTypeEnum = StrEnum(
-    "AllowedSubjectTokenTypeEnum",
+AllowedSubjectTokenType = StrEnum(
+    "AllowedSubjectTokenType",
     {
-        TokenTypeEnum(type_).name: TokenTypeEnum(type_).value
+        TokenType(type_).name: TokenType(type_).value
         for type_ in settings.TOKEN_EXCHANGE_ALLOWED_SUBJECT_TOKEN_TYPES
     },
 )

--- a/src/backend/token_exchange/factories.py
+++ b/src/backend/token_exchange/factories.py
@@ -6,7 +6,7 @@ import factory.fuzzy
 from django.conf import settings
 from faker import Faker
 
-from token_exchange.enums import AllowedRequestedTokenTypeEnum
+from token_exchange.enums import AllowedRequestedTokenType
 from token_exchange.services.token import TokenGenerator
 from token_exchange.structs import MenshenJWTGrantClaim
 
@@ -69,7 +69,7 @@ class JWTExchangedTokenFactory(ExchangedTokenFactory):
             ],
         )
     )
-    token_type = AllowedRequestedTokenTypeEnum.JWT
+    token_type = AllowedRequestedTokenType.JWT
     subject_sub = "ef7d37b4-080c-4df7-b0f8-3560dc7138aa"
     subject_email = "jane.doe@example.org"
     audiences = ["service:target"]

--- a/src/backend/token_exchange/models.py
+++ b/src/backend/token_exchange/models.py
@@ -14,7 +14,7 @@ from django.db.models import JSONField
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from .enums import TokenExchangeTokenTypeHint, TokenTypeEnum
+from .enums import TokenExchangeTokenTypeHint, TokenType
 from .structs import IntrospectionResponse
 
 logger = logging.getLogger(__name__)
@@ -29,8 +29,8 @@ def validate_action_scope_name(value: str) -> None:
 class TokenTypeChoices(models.TextChoices):
     """Token type choices for RFC 8693."""
 
-    ACCESS_TOKEN = TokenTypeEnum.ACCESS_TOKEN, _("Access Token")
-    JWT = TokenTypeEnum.JWT, _("JWT")
+    ACCESS_TOKEN = TokenType.ACCESS_TOKEN, _("Access Token")
+    JWT = TokenType.JWT, _("JWT")
 
 
 # Mapping between token type hint and token type choices
@@ -552,7 +552,7 @@ class ExchangedToken(BaseModel):
             active=True,
             scope=self.scope,
             username=self.subject_email or self.subject_sub,
-            token_type=TokenTypeEnum(self.token_type),
+            token_type=TokenType(self.token_type),
             exp=int(self.expires_at.timestamp()),
             iat=int(self.created_at.timestamp()),
             sub=self.subject_sub,

--- a/src/backend/token_exchange/services/request.py
+++ b/src/backend/token_exchange/services/request.py
@@ -13,9 +13,9 @@ from lasuite.oidc_resource_server.backend import ResourceServerBackend
 from requests import RequestException
 
 from ..enums import (
-    AllowedRequestedTokenTypeEnum,
+    AllowedRequestedTokenType,
     TokenExchangeResponseTokenType,
-    TokenTypeEnum,
+    TokenType,
 )
 from ..exceptions import (
     TokenExchangeConfigurationError,
@@ -258,7 +258,7 @@ class RequestService:
     @classmethod
     def _generate_exchange_token(  # noqa: PLR0913
         cls,
-        token_type: AllowedRequestedTokenTypeEnum,
+        token_type: AllowedRequestedTokenType,
         user_info: IntrospectionResponse,
         scope: str,
         audiences: list[str],
@@ -267,9 +267,9 @@ class RequestService:
     ) -> str:
         """Generate an exchange token given a token exchange request."""
         match token_type:
-            case TokenTypeEnum.ACCESS_TOKEN:
+            case TokenType.ACCESS_TOKEN:
                 return TokenGenerator.generate_opaque_token()
-            case TokenTypeEnum.JWT:
+            case TokenType.JWT:
                 if not cls.kid:
                     raise TokenExchangeConfigurationError("JWT signing key is not configured.")
                 try:
@@ -356,7 +356,7 @@ class RequestService:
         requested_token_type = (
             request.requested_token_type
             if request.requested_token_type
-            else AllowedRequestedTokenTypeEnum(TokenTypeEnum.ACCESS_TOKEN)
+            else AllowedRequestedTokenType(TokenType.ACCESS_TOKEN)
         )
         scope = " ".join(sorted({grant.scope for grant in grants}))
         audiences: list[str] = (

--- a/src/backend/token_exchange/structs.py
+++ b/src/backend/token_exchange/structs.py
@@ -12,12 +12,12 @@ from django.utils import timezone
 from joserfc.jwt import ClaimsOption, JWTClaimsRegistry
 
 from .enums import (
-    AllowedActorTokenTypeEnum,
-    AllowedRequestedTokenTypeEnum,
-    AllowedSubjectTokenTypeEnum,
+    AllowedActorTokenType,
+    AllowedRequestedTokenType,
+    AllowedSubjectTokenType,
     TokenExchangeResponseTokenType,
     TokenExchangeTokenTypeHint,
-    TokenTypeEnum,
+    TokenType,
 )
 
 
@@ -167,7 +167,7 @@ class IntrospectionResponse(
     iat: int | None = None
     iss: str | None = None
     aud: str | None = None
-    token_type: TokenTypeEnum | None = None
+    token_type: TokenType | None = None
 
     # Optionnal
     email: str | None = None
@@ -199,16 +199,16 @@ class TokenExchangeRequest(
     """
 
     subject_token: Annotated[str, msgspec.Meta(min_length=1)]
-    subject_token_type: AllowedSubjectTokenTypeEnum
+    subject_token_type: AllowedSubjectTokenType
     grant_type: Literal["urn:ietf:params:oauth:grant-type:token-exchange"] = (
         "urn:ietf:params:oauth:grant-type:token-exchange"
     )
     resource: str | None = None
     audience: str | None = None
     scope: str | None = None
-    requested_token_type: AllowedRequestedTokenTypeEnum | None = None
+    requested_token_type: AllowedRequestedTokenType | None = None
     actor_token: str | None = None
-    actor_token_type: AllowedActorTokenTypeEnum | None = None
+    actor_token_type: AllowedActorTokenType | None = None
 
     @property
     def audiences(self) -> list[str]:
@@ -288,7 +288,7 @@ class TokenExchangeResponse(
     """
 
     access_token: str
-    issued_token_type: AllowedRequestedTokenTypeEnum
+    issued_token_type: AllowedRequestedTokenType
     token_type: TokenExchangeResponseTokenType
     expires_in: Annotated[int, msgspec.Meta(le=settings.TOKEN_EXCHANGE_MAX_EXPIRES_IN)] = (
         settings.TOKEN_EXCHANGE_DEFAULT_EXPIRES_IN

--- a/src/backend/token_exchange/tests/services/test_request.py
+++ b/src/backend/token_exchange/tests/services/test_request.py
@@ -10,10 +10,10 @@ from requests import ConnectionError as ConnectionError_
 from requests import HTTPError
 
 from token_exchange.enums import (
-    AllowedRequestedTokenTypeEnum,
-    AllowedSubjectTokenTypeEnum,
+    AllowedRequestedTokenType,
+    AllowedSubjectTokenType,
     TokenExchangeResponseTokenType,
-    TokenTypeEnum,
+    TokenType,
 )
 from token_exchange.exceptions import (
     TokenExchangeConfigurationError,
@@ -39,7 +39,7 @@ def test_request_service_validate_target_only_unknown_audiences(source_service, 
     """Test the request service validate target method with only unknown audiences."""
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum(TokenTypeEnum.ACCESS_TOKEN),
+        subject_token_type=AllowedSubjectTokenType(TokenType.ACCESS_TOKEN),
         audience="service:foo",
     )
     with (
@@ -57,7 +57,7 @@ def test_request_service_validate_target_with_unknown_audience(source_service, c
     """Test the request service validate target method with unknown audience."""
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum(TokenTypeEnum.ACCESS_TOKEN),
+        subject_token_type=AllowedSubjectTokenType(TokenType.ACCESS_TOKEN),
         audience="service:target service:foo",
     )
     with (
@@ -77,7 +77,7 @@ def test_request_service_introspect_subject_token_request_failure(
     """Test the request service introspect subject token method when the request fails."""
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum(TokenTypeEnum.ACCESS_TOKEN),
+        subject_token_type=AllowedSubjectTokenType(TokenType.ACCESS_TOKEN),
         audience="service:target",
     )
 
@@ -113,7 +113,7 @@ def test_request_service_introspect_subject_token_suspicious_introspection_respo
     """
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum(TokenTypeEnum.ACCESS_TOKEN),
+        subject_token_type=AllowedSubjectTokenType(TokenType.ACCESS_TOKEN),
         audience="service:target",
     )
 
@@ -140,7 +140,7 @@ def test_request_service_introspect_subject_token_missing_identity(
     """Test the request service introspect subject token method when not identity is returned."""
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum(TokenTypeEnum.ACCESS_TOKEN),
+        subject_token_type=AllowedSubjectTokenType(TokenType.ACCESS_TOKEN),
         audience="service:target",
     )
 
@@ -173,7 +173,7 @@ def test_request_service_validate_pure_scopes_from_request(source_service):
     """
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum(TokenTypeEnum.ACCESS_TOKEN),
+        subject_token_type=AllowedSubjectTokenType(TokenType.ACCESS_TOKEN),
         audience="service:target",
         scope="target:read target:write",
     )
@@ -191,7 +191,7 @@ def test_request_service_validate_pure_scopes_from_request_with_extra_scopes(sou
     """Test the request service validate pure scopes method with extra scopes from the request."""
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum(TokenTypeEnum.ACCESS_TOKEN),
+        subject_token_type=AllowedSubjectTokenType(TokenType.ACCESS_TOKEN),
         audience="service:target",
         scope="target:read target:write extra",
     )
@@ -240,7 +240,7 @@ def test_request_service_validate_scope_action_from_request_with_granted_require
 
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum(TokenTypeEnum.ACCESS_TOKEN),
+        subject_token_type=AllowedSubjectTokenType(TokenType.ACCESS_TOKEN),
         audience="service:target",
         scope="action:update-target",
     )
@@ -272,7 +272,7 @@ def test_request_service_validate_scope_action_from_request_when_action_has_no_p
 
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum(TokenTypeEnum.ACCESS_TOKEN),
+        subject_token_type=AllowedSubjectTokenType(TokenType.ACCESS_TOKEN),
         audience="service:target",
         scope="action:update-target",
     )
@@ -315,7 +315,7 @@ def test_request_service_validate_scope_action_from_request_when_action_cannot_b
 
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum(TokenTypeEnum.ACCESS_TOKEN),
+        subject_token_type=AllowedSubjectTokenType(TokenType.ACCESS_TOKEN),
         audience="service:target",
         scope="action:update-target",
     )
@@ -332,12 +332,12 @@ def test_request_service_validate_scope_action_from_request_when_action_cannot_b
     assert "Missing required source scope(s): target:update" in caplog.messages
 
 
-@pytest.mark.parametrize("token_type", [TokenTypeEnum.ACCESS_TOKEN, TokenTypeEnum.JWT])
+@pytest.mark.parametrize("token_type", [TokenType.ACCESS_TOKEN, TokenType.JWT])
 def test_request_service_generate_exchange_token_with_type(token_type, source_service):
     """Test the request service generate exchange token method with a given token type."""
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum.ACCESS_TOKEN,
+        subject_token_type=AllowedSubjectTokenType.ACCESS_TOKEN,
         audience="service:target",
         scope="target:write",
         requested_token_type=token_type,
@@ -353,10 +353,10 @@ def test_request_service_generate_exchange_token_jwt_no_sub_claim(
     """Test the request service generate exchange token method with missing sub claim."""
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum.ACCESS_TOKEN,
+        subject_token_type=AllowedSubjectTokenType.ACCESS_TOKEN,
         audience="service:target",
         scope="target:write",
-        requested_token_type=AllowedRequestedTokenTypeEnum.JWT,
+        requested_token_type=AllowedRequestedTokenType.JWT,
     )
 
     # Monkeypatch OIDC backend token introspection
@@ -385,10 +385,10 @@ def test_request_service_generate_exchange_token_jwt_configuration(source_servic
     """Test the request service generate exchange token method with missing kid."""
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum.ACCESS_TOKEN,
+        subject_token_type=AllowedSubjectTokenType.ACCESS_TOKEN,
         audience="service:target",
         scope="target:write",
-        requested_token_type=AllowedSubjectTokenTypeEnum.JWT,
+        requested_token_type=AllowedSubjectTokenType.JWT,
     )
     monkeypatch.setattr(RequestService, "kid", None)
     with pytest.raises(TokenExchangeConfigurationError, match="JWT signing key is not configured."):
@@ -399,10 +399,10 @@ def test_request_service_generate_exchange_token_unsupported_type(source_service
     """Test the request service generate exchange token method with an unsupported token type."""
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum.ACCESS_TOKEN,
+        subject_token_type=AllowedSubjectTokenType.ACCESS_TOKEN,
         audience="service:target",
         scope="target:write",
-        requested_token_type=TokenTypeEnum.REFRESH_TOKEN,  # ty: ignore
+        requested_token_type=TokenType.REFRESH_TOKEN,  # ty: ignore
     )
     with pytest.raises(
         TokenExchangeConfigurationError, match="Configured request token type is not supported."
@@ -414,10 +414,10 @@ def test_request_service_generate_exchange_token_jwt_invalid_token(source_servic
     """Test the request service generate exchange token method generates an invalid JWT."""
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum.ACCESS_TOKEN,
+        subject_token_type=AllowedSubjectTokenType.ACCESS_TOKEN,
         audience="service:target",
         scope="target:write",
-        requested_token_type=AllowedSubjectTokenTypeEnum.JWT,
+        requested_token_type=AllowedSubjectTokenType.JWT,
     )
     monkeypatch.setattr(TokenGenerator, "generate_jwt", Mock(side_effect=ValueError()))
     with pytest.raises(TokenExchangeIssuingError, match="An error occurred while issuing JWT."):
@@ -425,13 +425,13 @@ def test_request_service_generate_exchange_token_jwt_invalid_token(source_servic
 
 
 @pytest.mark.parametrize(
-    "token_type", [AllowedRequestedTokenTypeEnum.ACCESS_TOKEN, AllowedRequestedTokenTypeEnum.JWT]
+    "token_type", [AllowedRequestedTokenType.ACCESS_TOKEN, AllowedRequestedTokenType.JWT]
 )
 def test_request_service_generate_exchange_response(source_service, token_type):
     """Test the request service generate exchange response."""
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum.ACCESS_TOKEN,
+        subject_token_type=AllowedSubjectTokenType.ACCESS_TOKEN,
         audience="service:target",
         scope="target:write",
         requested_token_type=token_type,
@@ -453,13 +453,13 @@ def test_request_service_generate_exchange_response(source_service, token_type):
 
 
 @pytest.mark.parametrize(
-    "token_type", [AllowedRequestedTokenTypeEnum.ACCESS_TOKEN, AllowedRequestedTokenTypeEnum.JWT]
+    "token_type", [AllowedRequestedTokenType.ACCESS_TOKEN, AllowedRequestedTokenType.JWT]
 )
 def test_request_service_generate_exchange_response_with_persist(source_service, token_type):
     """Test the request service generate exchange response."""
     request = TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=AllowedSubjectTokenTypeEnum.ACCESS_TOKEN,
+        subject_token_type=AllowedSubjectTokenType.ACCESS_TOKEN,
         audience="service:target",
         scope="target:write",
         requested_token_type=token_type,

--- a/src/backend/token_exchange/tests/test_models.py
+++ b/src/backend/token_exchange/tests/test_models.py
@@ -8,7 +8,7 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
-from token_exchange.enums import AllowedRequestedTokenTypeEnum
+from token_exchange.enums import AllowedRequestedTokenType
 from token_exchange.factories import (
     ActionScopeFactory,
     ActionScopeGrantFactory,
@@ -275,12 +275,12 @@ def test_exchangedtoken_to_introspection_response_invalid_token(expires_at, revo
 
 def test_exchangedtoken_to_introspection_response(settings):
     """Test the ExchangedToken to_introspection_response method."""
-    token = ExchangedTokenFactory.create(token_type=AllowedRequestedTokenTypeEnum.ACCESS_TOKEN)
+    token = ExchangedTokenFactory.create(token_type=AllowedRequestedTokenType.ACCESS_TOKEN)
     assert token.to_introspection_response() == IntrospectionResponse(
         active=True,
         scope=token.scope,
         username=token.subject_email or token.subject_sub,
-        token_type=AllowedRequestedTokenTypeEnum.ACCESS_TOKEN,
+        token_type=AllowedRequestedTokenType.ACCESS_TOKEN,
         exp=int(token.expires_at.timestamp()),
         iat=int(token.created_at.timestamp()),
         sub=token.subject_sub,

--- a/src/backend/token_exchange/tests/test_structs.py
+++ b/src/backend/token_exchange/tests/test_structs.py
@@ -9,10 +9,10 @@ import pytest
 from joserfc.jwt import ClaimsOption, JWTClaimsRegistry
 
 from token_exchange.enums import (
-    AllowedActorTokenTypeEnum,
+    AllowedActorTokenType,
     TokenExchangeResponseTokenType,
     TokenExchangeTokenTypeHint,
-    TokenTypeEnum,
+    TokenType,
 )
 from token_exchange.structs import (
     IntrospectionRequest,
@@ -124,7 +124,7 @@ def test_tokenexchangerequest_struct_decoding():
     """Test the TokenExchangeRequest struct decoding from JSON string."""
     payload = {
         "subject_token": "fake",
-        "subject_token_type": TokenTypeEnum.ACCESS_TOKEN,
+        "subject_token_type": TokenType.ACCESS_TOKEN,
         "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
         "resource": "https://target-service.com",
         "audience": " target1  target2 ",
@@ -145,7 +145,7 @@ def test_tokenexchangerequest_struct_decoding_with_only_required_fields():
     """Test the TokenExchangeRequest struct with only required fields."""
     payload = {
         "subject_token": "fake",
-        "subject_token_type": TokenTypeEnum.ACCESS_TOKEN,
+        "subject_token_type": TokenType.ACCESS_TOKEN,
         "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
     }
 
@@ -173,7 +173,7 @@ def test_tokenexchangerequest_struct_scope_invalid_actions(scope, match):
     """Test the TokenExchangeRequest struct action validation rules (invalid cases)."""
     payload = {
         "subject_token": "fake",
-        "subject_token_type": TokenTypeEnum.ACCESS_TOKEN,
+        "subject_token_type": TokenType.ACCESS_TOKEN,
         "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
         "scope": scope,
     }
@@ -186,7 +186,7 @@ def test_tokenexchangerequest_struct_scope_valid_actions():
     """Test the TokenExchangeRequest struct action validation rules (valid case)."""
     payload = {
         "subject_token": "fake",
-        "subject_token_type": TokenTypeEnum.ACCESS_TOKEN,
+        "subject_token_type": TokenType.ACCESS_TOKEN,
         "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
         "scope": "action:foo",
     }
@@ -199,7 +199,7 @@ def test_tokenexchangerequest_struct_ensure_actor_token_requirements():
     """Test the TokenExchangeRequest struct ensures actor_token requirements."""
     payload = {
         "subject_token": "fake",
-        "subject_token_type": TokenTypeEnum.ACCESS_TOKEN,
+        "subject_token_type": TokenType.ACCESS_TOKEN,
         "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
         "resource": "https://target-service.com",
         "scope": "action:foo",
@@ -214,22 +214,22 @@ def test_tokenexchangerequest_struct_ensure_actor_token_requirements():
         msgspec.json.decode(json.dumps(payload), type=TokenExchangeRequest)
 
     # Now add a token type
-    payload.update({"actor_token_type": AllowedActorTokenTypeEnum.ACCESS_TOKEN})
+    payload.update({"actor_token_type": AllowedActorTokenType.ACCESS_TOKEN})
     token_exchanged_request = msgspec.json.decode(json.dumps(payload), type=TokenExchangeRequest)
     assert token_exchanged_request.actor_token == "foo"
-    assert token_exchanged_request.actor_token_type == AllowedActorTokenTypeEnum.ACCESS_TOKEN
+    assert token_exchanged_request.actor_token_type == AllowedActorTokenType.ACCESS_TOKEN
 
 
 def test_tokenexchangerequest_struct_ensure_actor_token_type_requirements():
     """Test the TokenExchangeRequest struct ensures actor_token_type requirements."""
     payload = {
         "subject_token": "fake",
-        "subject_token_type": TokenTypeEnum.ACCESS_TOKEN,
+        "subject_token_type": TokenType.ACCESS_TOKEN,
         "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
         "resource": "https://target-service.com",
         "scope": "action:foo",
         "audience": " target1  target2 ",
-        "actor_token_type": TokenTypeEnum.ACCESS_TOKEN,
+        "actor_token_type": TokenType.ACCESS_TOKEN,
     }
 
     with pytest.raises(
@@ -242,24 +242,24 @@ def test_tokenexchangerequest_struct_ensure_actor_token_type_requirements():
     payload.update({"actor_token": "foo"})
     token_exchanged_request = msgspec.json.decode(json.dumps(payload), type=TokenExchangeRequest)
     assert token_exchanged_request.actor_token == "foo"
-    assert token_exchanged_request.actor_token_type == AllowedActorTokenTypeEnum.ACCESS_TOKEN
+    assert token_exchanged_request.actor_token_type == AllowedActorTokenType.ACCESS_TOKEN
 
 
 @pytest.mark.parametrize(
     ("subject_token_type", "requested_token_type", "actor_token", "actor_token_type"),
     [
-        (TokenTypeEnum.REFRESH_TOKEN, None, None, None),
-        (TokenTypeEnum.ID_TOKEN, None, None, None),
-        (TokenTypeEnum.SAML1, None, None, None),
-        (TokenTypeEnum.SAML2, None, None, None),
-        (TokenTypeEnum.ACCESS_TOKEN, TokenTypeEnum.REFRESH_TOKEN, None, None),
-        (TokenTypeEnum.ACCESS_TOKEN, TokenTypeEnum.ID_TOKEN, None, None),
-        (TokenTypeEnum.ACCESS_TOKEN, TokenTypeEnum.SAML1, None, None),
-        (TokenTypeEnum.ACCESS_TOKEN, TokenTypeEnum.SAML2, None, None),
-        (TokenTypeEnum.ACCESS_TOKEN, None, "foo", TokenTypeEnum.REFRESH_TOKEN),
-        (TokenTypeEnum.ACCESS_TOKEN, None, "foo", TokenTypeEnum.ID_TOKEN),
-        (TokenTypeEnum.ACCESS_TOKEN, None, "foo", TokenTypeEnum.SAML1),
-        (TokenTypeEnum.ACCESS_TOKEN, None, "foo", TokenTypeEnum.SAML2),
+        (TokenType.REFRESH_TOKEN, None, None, None),
+        (TokenType.ID_TOKEN, None, None, None),
+        (TokenType.SAML1, None, None, None),
+        (TokenType.SAML2, None, None, None),
+        (TokenType.ACCESS_TOKEN, TokenType.REFRESH_TOKEN, None, None),
+        (TokenType.ACCESS_TOKEN, TokenType.ID_TOKEN, None, None),
+        (TokenType.ACCESS_TOKEN, TokenType.SAML1, None, None),
+        (TokenType.ACCESS_TOKEN, TokenType.SAML2, None, None),
+        (TokenType.ACCESS_TOKEN, None, "foo", TokenType.REFRESH_TOKEN),
+        (TokenType.ACCESS_TOKEN, None, "foo", TokenType.ID_TOKEN),
+        (TokenType.ACCESS_TOKEN, None, "foo", TokenType.SAML1),
+        (TokenType.ACCESS_TOKEN, None, "foo", TokenType.SAML2),
     ],
 )
 def test_tokenexchangerequest_struct_not_allowed_token_types(
@@ -289,13 +289,13 @@ def test_tokenexchangeresponse_struct_decoding_with_only_required_fields():
     """Test the TokenExchangeResponse struct decoding withn only required fields."""
     payload = {
         "access_token": "fake_access",
-        "issued_token_type": TokenTypeEnum.ACCESS_TOKEN,
+        "issued_token_type": TokenType.ACCESS_TOKEN,
         "token_type": TokenExchangeResponseTokenType.BEARER,
     }
 
     token_exchanged_response = msgspec.json.decode(json.dumps(payload), type=TokenExchangeResponse)
     assert token_exchanged_response.access_token == "fake_access"
-    assert token_exchanged_response.issued_token_type == TokenTypeEnum.ACCESS_TOKEN
+    assert token_exchanged_response.issued_token_type == TokenType.ACCESS_TOKEN
     assert token_exchanged_response.token_type == TokenExchangeResponseTokenType.BEARER
     assert token_exchanged_response.expires_in == 3600
     assert token_exchanged_response.scope is None
@@ -306,7 +306,7 @@ def test_tokenexchangeresponse_struct_decoding_with_optional_fields():
     """Test the TokenExchangeResponse struct decoding with optional fields."""
     payload = {
         "access_token": "fake_access",
-        "issued_token_type": TokenTypeEnum.ACCESS_TOKEN,
+        "issued_token_type": TokenType.ACCESS_TOKEN,
         "token_type": TokenExchangeResponseTokenType.BEARER,
         "expires_in": 1800,
         "scope": "foo",
@@ -315,7 +315,7 @@ def test_tokenexchangeresponse_struct_decoding_with_optional_fields():
 
     token_exchanged_response = msgspec.json.decode(json.dumps(payload), type=TokenExchangeResponse)
     assert token_exchanged_response.access_token == "fake_access"
-    assert token_exchanged_response.issued_token_type == TokenTypeEnum.ACCESS_TOKEN
+    assert token_exchanged_response.issued_token_type == TokenType.ACCESS_TOKEN
     assert token_exchanged_response.token_type == TokenExchangeResponseTokenType.BEARER
     assert token_exchanged_response.expires_in == 1800
     assert token_exchanged_response.scope == "foo"
@@ -326,7 +326,7 @@ def test_tokenexchangeresponse_struct_expires_in(settings):
     """Test the TokenExchangeResponse struct expiracy."""
     payload = {
         "access_token": "fake_access",
-        "issued_token_type": TokenTypeEnum.ACCESS_TOKEN,
+        "issued_token_type": TokenType.ACCESS_TOKEN,
         "token_type": TokenExchangeResponseTokenType.BEARER,
         "expires_in": settings.TOKEN_EXCHANGE_MAX_EXPIRES_IN + 1,
     }

--- a/src/backend/token_exchange/tests/test_views.py
+++ b/src/backend/token_exchange/tests/test_views.py
@@ -10,7 +10,7 @@ from requests import HTTPError
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from token_exchange.enums import TokenTypeEnum
+from token_exchange.enums import TokenType
 from token_exchange.factories import (
     ExchangedTokenFactory,
     ServiceProviderFactory,
@@ -128,7 +128,7 @@ def test_exchange_view_with_introspection_error(source_api_client, monkeypatch, 
     payload = {
         "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
         "subject_token": "fake-access-token",
-        "subject_token_type": TokenTypeEnum.ACCESS_TOKEN,
+        "subject_token_type": TokenType.ACCESS_TOKEN,
         "audience": "service:target",
     }
 
@@ -175,8 +175,8 @@ def test_exchange_view_with_inactive_rule(source_api_client, source_service, cap
     ("subject_token", "subject_token_type"),
     [
         # Could be fake since it won't be introspected
-        ("fake-access-token", TokenTypeEnum.ACCESS_TOKEN),
-        ("{}", TokenTypeEnum.JWT),
+        ("fake-access-token", TokenType.ACCESS_TOKEN),
+        ("{}", TokenType.JWT),
     ],
 )
 def test_exchange_view_with_subject_token_type(
@@ -218,7 +218,7 @@ def test_exchange_view_with_subject_token_type(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "requested_token_type",
-    [TokenTypeEnum.ACCESS_TOKEN, TokenTypeEnum.JWT],
+    [TokenType.ACCESS_TOKEN, TokenType.JWT],
 )
 def test_exchange_view_with_requested_token_type(requested_token_type, source_api_client):
     """Test the TokenExchangeView with different requested token types."""


### PR DESCRIPTION
## Purpose

Many Enums are suffixed by `Enum`, we think it's not required and must be simplified.

> Who da fuck is naming every variable with its type as a suffix? — **Mickael Scott**

## Proposal

- [x] remove enums' `Enum` suffixes
