### PR TITLE
[client] Remove Menshen prefixes in class names

### DIFF
--- a/src/client/README.md
+++ b/src/client/README.md
@@ -10,7 +10,7 @@ The API client is available from PyPI and can be added to your project using:
 
 ```bash
 uv add menshen_client
-# or 
+# or
 pip install menshen_client
 ```
 
@@ -20,8 +20,8 @@ pip install menshen_client
 
 You can create your client configuration using the following snippet:
 
-```python 
-from menshen_client import MenshenClient, MenshenConfiguration
+```python
+from menshen_client import MenshenConfiguration, TokenExchangeClient
 
 # Configure the client
 config = MenshenConfiguration(
@@ -31,7 +31,7 @@ config = MenshenConfiguration(
 )
 
 # Create the client instance
-client = MenshenClient(config=config)
+client = TokenExchangeClient(config=config)
 ```
 
 In this example, the client identifier and secret are those provided by your
@@ -41,12 +41,12 @@ for your service. The `server_root_url` is the root URL of your Menshen server.
 ### Token exchange request
 
 To generate an exchange token given a subject token and a related token type
-use: 
+use:
 
 ```python
 from menshen_client import (
-    MenshenSupportedTokenType, 
-    TokenExchangeRequest, 
+    MenshenSupportedTokenType,
+    TokenExchangeRequest,
     TokenExchangeResponse,
 )
 
@@ -70,10 +70,10 @@ The token exchange response contains the exchanged token that can be used to
 query the target resource server:
 
 ```python
-import requests 
+import requests
 
 resources = requests.get(
-    "https://target.example.org/external_api/v1.0/resource/", 
+    "https://target.example.org/external_api/v1.0/resource/",
     headers={
         "Authorization": f"Bearer {exchange_response.access_token}",
         "Content-Type": "application/json",
@@ -92,9 +92,9 @@ tokens _via_ your autorization server instance using:
 
 ```python
 from menshen_client import (
-    MenshenSupportedTokenType, 
-    IntrospectionRequest, 
+    IntrospectionRequest,
     IntrospectionResponse,
+    MenshenSupportedTokenType,
 )
 
 # Create the token instrospection request
@@ -124,8 +124,8 @@ Menshen instance dedicated endpoint:
 
 ```python
 from menshen_client import (
-    MenshenSupportedTokenType, 
-    RevocationRequest, 
+    MenshenSupportedTokenType,
+    RevocationRequest,
 )
 
 # Create the token revocation request

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -21,10 +21,10 @@ pip install menshen_client
 You can create your client configuration using the following snippet:
 
 ```python
-from menshen_client import MenshenConfiguration, TokenExchangeClient
+from menshen_client import Configuration, TokenExchangeClient
 
 # Configure the client
-config = MenshenConfiguration(
+config = Configuration(
    client_id="acme",
    client_secret="super-secret",
    server_root_url="https://menshen.example.org",

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -45,15 +45,15 @@ use:
 
 ```python
 from menshen_client import (
-    MenshenSupportedTokenType,
     TokenExchangeRequest,
     TokenExchangeResponse,
+    TokenType,
 )
 
 # Create the token exchange request
 exchange_request = TokenExchangeRequest(
     subject_token="exampletoken",
-    subject_token_type=MenshenSupportedTokenType.ACCESS_TOKEN,
+    subject_token_type=TokenType.ACCESS_TOKEN,
     audience="https://target.example.org",
     scope="target:write",
 )
@@ -94,13 +94,13 @@ tokens _via_ your autorization server instance using:
 from menshen_client import (
     IntrospectionRequest,
     IntrospectionResponse,
-    MenshenSupportedTokenType,
+    TokenType,
 )
 
 # Create the token instrospection request
 introspection_request = IntrospectionRequest(
     token="exampletoken",
-    token_type_hint=MenshenSupportedTokenType.ACCESS_TOKEN,
+    token_type_hint=TokenType.ACCESS_TOKEN,
 )
 
 # Get the token introspection response
@@ -124,14 +124,14 @@ Menshen instance dedicated endpoint:
 
 ```python
 from menshen_client import (
-    MenshenSupportedTokenType,
     RevocationRequest,
+    TokenType,
 )
 
 # Create the token revocation request
 revocation_request = RevocationRequest(
     token="exampletoken",
-    token_type_hint=MenshenSupportedTokenType.ACCESS_TOKEN,
+    token_type_hint=TokenType.ACCESS_TOKEN,
 )
 
 # Token revocation response is empty

--- a/src/client/menshen_client/__init__.py
+++ b/src/client/menshen_client/__init__.py
@@ -1,7 +1,7 @@
 """Menshen client."""
 
 from .client import TokenExchangeClient
-from .enums import MenshenSupportedTokenType, TokenExchangeResponseTokenType
+from .enums import TokenExchangeResponseTokenType, TokenType
 from .schemas import (
     IntrospectionRequest,
     IntrospectionResponse,
@@ -16,7 +16,7 @@ __all__ = (
     "IntrospectionResponse",
     "TokenExchangeClient",
     "MenshenConfiguration",
-    "MenshenSupportedTokenType",
+    "TokenType",
     "RevocationRequest",
     "TokenExchangeRequest",
     "TokenExchangeResponse",

--- a/src/client/menshen_client/__init__.py
+++ b/src/client/menshen_client/__init__.py
@@ -1,6 +1,6 @@
 """Menshen client."""
 
-from .client import MenshenClient
+from .client import TokenExchangeClient
 from .enums import MenshenSupportedTokenType, TokenExchangeResponseTokenType
 from .schemas import (
     IntrospectionRequest,
@@ -14,7 +14,7 @@ from .schemas import (
 __all__ = (
     "IntrospectionRequest",
     "IntrospectionResponse",
-    "MenshenClient",
+    "TokenExchangeClient",
     "MenshenConfiguration",
     "MenshenSupportedTokenType",
     "RevocationRequest",

--- a/src/client/menshen_client/__init__.py
+++ b/src/client/menshen_client/__init__.py
@@ -3,9 +3,9 @@
 from .client import TokenExchangeClient
 from .enums import TokenExchangeResponseTokenType, TokenType
 from .schemas import (
+    Configuration,
     IntrospectionRequest,
     IntrospectionResponse,
-    MenshenConfiguration,
     RevocationRequest,
     TokenExchangeRequest,
     TokenExchangeResponse,
@@ -15,7 +15,7 @@ __all__ = (
     "IntrospectionRequest",
     "IntrospectionResponse",
     "TokenExchangeClient",
-    "MenshenConfiguration",
+    "Configuration",
     "TokenType",
     "RevocationRequest",
     "TokenExchangeRequest",

--- a/src/client/menshen_client/client.py
+++ b/src/client/menshen_client/client.py
@@ -10,9 +10,9 @@ from requests.exceptions import JSONDecodeError
 
 from .exceptions import ResponseParsingError
 from .schemas import (
+    Configuration,
     IntrospectionRequest,
     IntrospectionResponse,
-    MenshenConfiguration,
     RevocationRequest,
     TokenExchangeRequest,
     TokenExchangeResponse,
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 class TokenExchangeClient:
     """Token Exchange API client."""
 
-    def __init__(self, config: MenshenConfiguration) -> None:
+    def __init__(self, config: Configuration) -> None:
         """Instantiate the API client."""
         self.config = config
         self.session = requests.Session()

--- a/src/client/menshen_client/client.py
+++ b/src/client/menshen_client/client.py
@@ -21,8 +21,8 @@ from .schemas import (
 logger = logging.getLogger(__name__)
 
 
-class MenshenClient:
-    """Menshen API client."""
+class TokenExchangeClient:
+    """Token Exchange API client."""
 
     def __init__(self, config: MenshenConfiguration) -> None:
         """Instantiate the API client."""

--- a/src/client/menshen_client/enums.py
+++ b/src/client/menshen_client/enums.py
@@ -3,7 +3,7 @@
 from enum import StrEnum
 
 
-class MenshenSupportedTokenType(StrEnum):
+class TokenType(StrEnum):
     """
     Token type identifier for RFC 8693.
 

--- a/src/client/menshen_client/schemas.py
+++ b/src/client/menshen_client/schemas.py
@@ -12,15 +12,15 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class MenshenConfiguration:
+class Configuration:
     """
-    Menshen server configuration.
+    Token exchange server configuration.
 
     Expected configuration:
 
-        - client_id: the client identifier for the menshen-registered service
-        - client_secret: the client secret for the menshen-registered service
-        - server_root_url: target menshen server root URL, e.g. https://menshen.example.org
+        - client_id: the client identifier for the registered service
+        - client_secret: the client secret for the registered service
+        - server_root_url: target token-exchange server root URL, e.g. https://menshen.example.org
         - token_endpoint: the token exchange API endpoint path
         - introspection: the exchanged token introspection API endpoint path
         - revocation_endpoint: the exchanged token revocation API endpoint path

--- a/src/client/menshen_client/schemas.py
+++ b/src/client/menshen_client/schemas.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass
 from typing import Literal
 
-from .enums import MenshenSupportedTokenType, TokenExchangeResponseTokenType
+from .enums import TokenExchangeResponseTokenType, TokenType
 
 logger = logging.getLogger(__name__)
 
@@ -72,16 +72,16 @@ class TokenExchangeRequest:
     """
 
     subject_token: str
-    subject_token_type: MenshenSupportedTokenType
+    subject_token_type: TokenType
     grant_type: Literal["urn:ietf:params:oauth:grant-type:token-exchange"] = (
         "urn:ietf:params:oauth:grant-type:token-exchange"
     )
     resource: str | None = None
     audience: str | None = None
     scope: str | None = None
-    requested_token_type: MenshenSupportedTokenType | None = None
+    requested_token_type: TokenType | None = None
     actor_token: str | None = None
-    actor_token_type: MenshenSupportedTokenType | None = None
+    actor_token_type: TokenType | None = None
 
 
 @dataclass
@@ -115,7 +115,7 @@ class TokenExchangeResponse:
     """
 
     access_token: str
-    issued_token_type: MenshenSupportedTokenType
+    issued_token_type: TokenType
     token_type: TokenExchangeResponseTokenType
     expires_in: int
     grants: list[MenshenJWTGrantClaim]
@@ -138,7 +138,7 @@ class IntrospectionRequest:
     """
 
     token: str
-    token_type_hint: MenshenSupportedTokenType | None = None
+    token_type_hint: TokenType | None = None
 
 
 @dataclass
@@ -161,7 +161,7 @@ class IntrospectionResponse:
     iat: int | None = None
     iss: str | None = None
     aud: str | None = None
-    token_type: MenshenSupportedTokenType | None = None
+    token_type: TokenType | None = None
 
     # Optionnal
     email: str | None = None
@@ -179,4 +179,4 @@ class RevocationRequest:
     """
 
     token: str
-    token_type_hint: MenshenSupportedTokenType | None = None
+    token_type_hint: TokenType | None = None

--- a/src/client/tests/conftest.py
+++ b/src/client/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from menshen_client.client import TokenExchangeClient
 from menshen_client.enums import TokenExchangeResponseTokenType, TokenType
 from menshen_client.schemas import (
-    MenshenConfiguration,
+    Configuration,
     MenshenJWTGrantClaim,
     MenshenJWTGrantClaimThrottling,
     TokenExchangeRequest,
@@ -32,9 +32,9 @@ def server_root_url() -> str:
 
 
 @pytest.fixture
-def config(client_id, client_secret, server_root_url) -> MenshenConfiguration:
+def config(client_id, client_secret, server_root_url) -> Configuration:
     """Menshen client test configuration."""
-    return MenshenConfiguration(
+    return Configuration(
         client_id=client_id, client_secret=client_secret, server_root_url=server_root_url
     )
 

--- a/src/client/tests/conftest.py
+++ b/src/client/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from menshen_client.client import MenshenClient
+from menshen_client.client import TokenExchangeClient
 from menshen_client.enums import MenshenSupportedTokenType, TokenExchangeResponseTokenType
 from menshen_client.schemas import (
     MenshenConfiguration,
@@ -42,7 +42,7 @@ def config(client_id, client_secret, server_root_url) -> MenshenConfiguration:
 @pytest.fixture
 def client(config):
     """Get configured Menshen client."""
-    return MenshenClient(config=config)
+    return TokenExchangeClient(config=config)
 
 
 @pytest.fixture

--- a/src/client/tests/conftest.py
+++ b/src/client/tests/conftest.py
@@ -3,7 +3,7 @@
 import pytest
 
 from menshen_client.client import TokenExchangeClient
-from menshen_client.enums import MenshenSupportedTokenType, TokenExchangeResponseTokenType
+from menshen_client.enums import TokenExchangeResponseTokenType, TokenType
 from menshen_client.schemas import (
     MenshenConfiguration,
     MenshenJWTGrantClaim,
@@ -50,7 +50,7 @@ def token_exchange_request():
     """Generate a token exchange request."""
     return TokenExchangeRequest(
         subject_token="foo",
-        subject_token_type=MenshenSupportedTokenType.ACCESS_TOKEN,
+        subject_token_type=TokenType.ACCESS_TOKEN,
     )
 
 
@@ -59,7 +59,7 @@ def token_exchange_response():
     """Generate a token exchange response."""
     return TokenExchangeResponse(
         access_token="foo",
-        issued_token_type=MenshenSupportedTokenType.ACCESS_TOKEN,
+        issued_token_type=TokenType.ACCESS_TOKEN,
         token_type=TokenExchangeResponseTokenType.BEARER,
         expires_in=3600,
         grants=[

--- a/src/client/tests/test_client.py
+++ b/src/client/tests/test_client.py
@@ -7,7 +7,7 @@ import pytest
 from requests import HTTPError
 
 from menshen_client.client import TokenExchangeClient
-from menshen_client.enums import MenshenSupportedTokenType, TokenExchangeResponseTokenType
+from menshen_client.enums import TokenExchangeResponseTokenType, TokenType
 from menshen_client.exceptions import ResponseParsingError
 from menshen_client.schemas import (
     IntrospectionRequest,
@@ -54,7 +54,7 @@ def test_client_exchange_token(client, responses, token_exchange_request, token_
 
     assert isinstance(exchanged_token, TokenExchangeResponse)
     assert exchanged_token.access_token == "foo"
-    assert exchanged_token.issued_token_type == MenshenSupportedTokenType.ACCESS_TOKEN
+    assert exchanged_token.issued_token_type == TokenType.ACCESS_TOKEN
     assert exchanged_token.token_type == TokenExchangeResponseTokenType.BEARER
     assert exchanged_token.expires_in == 3600
     assert exchanged_token.grants[0].audience_id == "service:target"

--- a/src/client/tests/test_client.py
+++ b/src/client/tests/test_client.py
@@ -10,9 +10,9 @@ from menshen_client.client import TokenExchangeClient
 from menshen_client.enums import TokenExchangeResponseTokenType, TokenType
 from menshen_client.exceptions import ResponseParsingError
 from menshen_client.schemas import (
+    Configuration,
     IntrospectionRequest,
     IntrospectionResponse,
-    MenshenConfiguration,
     RevocationRequest,
     TokenExchangeResponse,
 )
@@ -20,7 +20,7 @@ from menshen_client.schemas import (
 
 def test_client_init():
     """Test the TokenExchangeClient instantiation."""
-    config = MenshenConfiguration(
+    config = Configuration(
         client_id="foo",
         client_secret="bar",
         server_root_url="https://menshen.example.org",

--- a/src/client/tests/test_client.py
+++ b/src/client/tests/test_client.py
@@ -1,4 +1,4 @@
-"""Tests for the MenshenClient."""
+"""Tests for the TokenExchangeClient."""
 
 import logging
 from dataclasses import asdict
@@ -6,7 +6,7 @@ from dataclasses import asdict
 import pytest
 from requests import HTTPError
 
-from menshen_client.client import MenshenClient
+from menshen_client.client import TokenExchangeClient
 from menshen_client.enums import MenshenSupportedTokenType, TokenExchangeResponseTokenType
 from menshen_client.exceptions import ResponseParsingError
 from menshen_client.schemas import (
@@ -19,13 +19,13 @@ from menshen_client.schemas import (
 
 
 def test_client_init():
-    """Test the MenshenClient instantiation."""
+    """Test the TokenExchangeClient instantiation."""
     config = MenshenConfiguration(
         client_id="foo",
         client_secret="bar",
         server_root_url="https://menshen.example.org",
     )
-    client = MenshenClient(config=config)
+    client = TokenExchangeClient(config=config)
     assert client.config == config
     assert client.session
     assert client.session.auth.username == config.client_id  # ty: ignore
@@ -34,7 +34,7 @@ def test_client_init():
 
 @pytest.mark.parametrize("status", [401, 403, 500, 502])
 def test_client_exchange_raises_for_status(client, responses, status, token_exchange_request):
-    """Test the MenshenClient exchange method with an invalid response status."""
+    """Test the TokenExchangeClient exchange method with an invalid response status."""
     responses.post(
         "https://menshen.example.org/auth/token/exchange/",
         status=status,
@@ -44,7 +44,7 @@ def test_client_exchange_raises_for_status(client, responses, status, token_exch
 
 
 def test_client_exchange_token(client, responses, token_exchange_request, token_exchange_response):
-    """Test the MenshenClient exchange method with an invalid response status."""
+    """Test the TokenExchangeClient exchange method with an invalid response status."""
     responses.post(
         "https://menshen.example.org/auth/token/exchange/",
         status=200,
@@ -67,7 +67,7 @@ def test_client_exchange_token(client, responses, token_exchange_request, token_
 def test_client_exchange_token_with_extra_field_in_response_payload(
     client, responses, token_exchange_request, token_exchange_response, caplog
 ):
-    """Test the MenshenClient exchange method with an extra field in the response."""
+    """Test the TokenExchangeClient exchange method with an extra field in the response."""
     payload = asdict(token_exchange_response)
     payload.update({"foo": "bar"})  # add an extra field
     responses.post(
@@ -97,7 +97,7 @@ def test_client_exchange_token_with_extra_field_in_response_payload(
 def test_client_exchange_token_with_missing_fields_in_response_payload(  # noqa: PLR0913
     client, responses, token_exchange_request, payload, missing, caplog
 ):
-    """Test the MenshenClient exchange method with missing fields in the response."""
+    """Test the TokenExchangeClient exchange method with missing fields in the response."""
     responses.post(
         "https://menshen.example.org/auth/token/exchange/",
         status=200,
@@ -118,7 +118,7 @@ def test_client_exchange_token_with_missing_fields_in_response_payload(  # noqa:
 def test_client_exchange_token_with_invalid_response_body(
     client, responses, token_exchange_request, caplog, body
 ):
-    """Test the MenshenClient exchange method with an invalid response body."""
+    """Test the TokenExchangeClient exchange method with an invalid response body."""
     responses.post(
         "https://menshen.example.org/auth/token/exchange/",
         status=200,
@@ -137,7 +137,7 @@ def test_client_exchange_token_with_invalid_response_body(
 
 @pytest.mark.parametrize("status", [401, 403, 500, 502])
 def test_client_introspect_raises_for_status(client, responses, status):
-    """Test the MenshenClient introspect method with an invalid response status."""
+    """Test the TokenExchangeClient introspect method with an invalid response status."""
     responses.post(
         "https://menshen.example.org/auth/token/introspect/",
         status=status,
@@ -147,7 +147,7 @@ def test_client_introspect_raises_for_status(client, responses, status):
 
 
 def test_client_introspect_token(client, responses):
-    """Test the MenshenClient introspect method with an invalid response status."""
+    """Test the TokenExchangeClient introspect method with an invalid response status."""
     responses.post(
         "https://menshen.example.org/auth/token/introspect/",
         status=200,
@@ -160,7 +160,7 @@ def test_client_introspect_token(client, responses):
 
 
 def test_client_introspect_token_with_extra_field_in_response_payload(client, responses, caplog):
-    """Test the MenshenClient introspect method with an extra field in the response."""
+    """Test the TokenExchangeClient introspect method with an extra field in the response."""
     payload = asdict(IntrospectionResponse(active=True))
     payload.update({"foo": "bar"})  # add an extra field
     responses.post(
@@ -182,7 +182,7 @@ def test_client_introspect_token_with_extra_field_in_response_payload(client, re
 def test_client_introspect_token_with_missing_fields_in_response_payload(  # noqa: PLR0913
     client, responses, caplog
 ):
-    """Test the MenshenClient introspect method with missing fields in the response."""
+    """Test the TokenExchangeClient introspect method with missing fields in the response."""
     responses.post(
         "https://menshen.example.org/auth/token/introspect/",
         status=200,
@@ -201,7 +201,7 @@ def test_client_introspect_token_with_missing_fields_in_response_payload(  # noq
 
 @pytest.mark.parametrize("body", ["not json", None, ""])
 def test_client_introspect_token_with_invalid_response_body(client, responses, caplog, body):
-    """Test the MenshenClient introspect method with an invalid response body."""
+    """Test the TokenExchangeClient introspect method with an invalid response body."""
     responses.post(
         "https://menshen.example.org/auth/token/introspect/",
         status=200,
@@ -220,7 +220,7 @@ def test_client_introspect_token_with_invalid_response_body(client, responses, c
 
 @pytest.mark.parametrize("status", [401, 403, 500, 502])
 def test_client_revoke_raises_for_status(client, responses, status):
-    """Test the MenshenClient revoke method with an invalid response status."""
+    """Test the TokenExchangeClient revoke method with an invalid response status."""
     responses.post(
         "https://menshen.example.org/auth/token/revoke/",
         status=status,
@@ -231,7 +231,7 @@ def test_client_revoke_raises_for_status(client, responses, status):
 
 @pytest.mark.parametrize("body", [None, "", "{}", '{"foo": "bar"}'])
 def test_client_revoke_token(client, responses, body):
-    """Test the MenshenClient revoke method with various response content."""
+    """Test the TokenExchangeClient revoke method with various response content."""
     responses.post(
         "https://menshen.example.org/auth/token/revoke/",
         status=200,

--- a/src/client/tests/test_schemas.py
+++ b/src/client/tests/test_schemas.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from menshen_client import MenshenConfiguration
+from menshen_client import Configuration
 
 
 @pytest.mark.parametrize("scheme", ["http", "https"])
@@ -36,8 +36,8 @@ from menshen_client import MenshenConfiguration
     ],
 )
 def test_menshen_configuration_properties(scheme, base_url, expected):
-    """Test MenshenConfiguration properties."""
-    config = MenshenConfiguration(
+    """Test Configuration properties."""
+    config = Configuration(
         client_id="foo",
         client_secret="bar",
         server_root_url=f"{scheme}://{base_url}",
@@ -48,8 +48,8 @@ def test_menshen_configuration_properties(scheme, base_url, expected):
 
 
 def test_menshen_configuration_properties_trailing_slashes():
-    """Test MenshenConfiguration properties URLs with missing trailing slashes."""
-    config = MenshenConfiguration(
+    """Test Configuration properties URLs with missing trailing slashes."""
+    config = Configuration(
         client_id="foo",
         client_secret="bar",
         server_root_url="https://menshen.example.org/",


### PR DESCRIPTION
## Purpose

As suggested by @lebaudantoine, there is no need to namespace our client (and other classes) by the `Menshen` prefix. We need to move to simpler, more generic naming convention.

## Proposal

- [x] rename `MenshenClient` to `TokenExchangeClient`
- [x] rename `MenshenSupportedTokenType` to `TokenType`
- [x] rename `MenshenConfiguration` to `Configuration`
