### PR TITLE
👷(project) fix docker login gh action pinned version

### DIFF
--- a/.github/workflows/_docker-publish.yml
+++ b/.github/workflows/_docker-publish.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Login to DockerHub
         if: ${{ inputs.should_push }}
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}


### PR DESCRIPTION
## Purpose

The hash and version of the docker login github action don't match.

## Proposal

- [x] use a semver pattern instead of just major releases
