### PR TITLE
🔖(minor) bump release to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-29
+
 ### Changed
 
 - Remove enums `Enum` suffix
@@ -27,5 +29,6 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 - Implement base Token Exchange (RFC 8693) endpoints
 
-[unreleased]: https://github.com/suitenumerique/menshen/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/suitenumerique/menshen/compare/v0.2.0...HEAD
+[v0.2.0]: https://github.com/suitenumerique/menshen/releases/v0.2.0
 [v0.1.0]: https://github.com/suitenumerique/menshen/releases/v0.1.0

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "uv_build"
 
 [project]
 name = "menshen"
-version = "0.1.0"
+version = "0.2.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -640,7 +640,7 @@ wheels = [
 
 [[package]]
 name = "menshen"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "dj-database-url" },

--- a/src/helm/helmfile.yaml.gotmpl
+++ b/src/helm/helmfile.yaml.gotmpl
@@ -1,7 +1,7 @@
 environments:
   dev:
     values:
-      - version: 0.1.0
+      - version: 0.2.0
 ---
 repositories:
 - name: dev-backends


### PR DESCRIPTION
### Changed

- Remove enums `Enum` suffix
- Switch from DRF to Django-Ninja API framework

#### Dependencies

- Upgrade `django` to `6.0.7`
- Upgrade `django-lasuite` to `0.0.27`
- Upgrade `drf-spectacular` to `0.30.0`
- Upgrade `sentry-sdk` to `2.66.1`
- Upgrade `uvicorn` to `0.51.0`
