### PR TITLE
🚀(backend) update production running command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `--app` flag in the container production command
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -154,6 +154,7 @@ USER ${DOCKER_USER}
 
 # Copy dependencies
 COPY --from=back-builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
 # Copy statics
 COPY --from=link-collector ${MENSHEN_STATIC_ROOT} ${MENSHEN_STATIC_ROOT}
@@ -162,9 +163,10 @@ COPY --from=link-collector ${MENSHEN_STATIC_ROOT} ${MENSHEN_STATIC_ROOT}
 # WEB_CONCURRENCY: number of workers to run <=> --workers=4
 ENV WEB_CONCURRENCY=4
 CMD [\
-  "/app/.venv/bin/uvicorn",\
-  "--app-dir=/app",\
+  "uvicorn",\
   "--host=0.0.0.0",\
+  "--port=8000",\
+  "--proxy-headers",\
   "--timeout-graceful-shutdown=300",\
   "--limit-max-requests=20000",\
   "--lifespan=off",\


### PR DESCRIPTION
## Purpose

In the Docker image, as the workdir is `/app`, we do not need to add the `--app` uvicorn option.

## Proposal

- [x] add `/app/.venv/bin` to the `$PATH`
- [x] remove Uvicorn's `--app` flag
- [x] add Uvicorn's `--port` flag
