### PR TITLE
➖(backend) remove `django-cors-headers` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 - Remove `--app` flag in the container production command
 
+### Removed
+
+- clean unused `django-cors-headers` configured dependency
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/backend/menshen/settings.py
+++ b/src/backend/menshen/settings.py
@@ -160,7 +160,6 @@ class Base(Configuration):
         "django.contrib.sessions.middleware.SessionMiddleware",
         "django.middleware.locale.LocaleMiddleware",
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
-        "corsheaders.middleware.CorsMiddleware",
         "django.middleware.common.CommonMiddleware",
         "django.middleware.csrf.CsrfViewMiddleware",
         "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -177,7 +176,6 @@ class Base(Configuration):
     INSTALLED_APPS = [
         "token_exchange",
         # Third party apps
-        "corsheaders",
         "dockerflow.django",
         # Django
         "django.contrib.admin",
@@ -244,12 +242,6 @@ class Base(Configuration):
     EMAIL_USE_TLS = values.BooleanValue(False)
     EMAIL_USE_SSL = values.BooleanValue(False)
     EMAIL_FROM = values.Value("from@example.com")
-
-    # CORS
-    CORS_ALLOW_CREDENTIALS = True
-    CORS_ALLOW_ALL_ORIGINS = values.BooleanValue(False)
-    CORS_ALLOWED_ORIGINS = values.ListValue([])
-    CORS_ALLOWED_ORIGIN_REGEXES = values.ListValue([])
 
     # Sentry
     SENTRY_DSN = values.URLValue(None, environ_name="SENTRY_DSN", environ_prefix=None)
@@ -520,7 +512,6 @@ class Development(Base):
     """
 
     ALLOWED_HOSTS = ["*"]
-    CORS_ALLOW_ALL_ORIGINS = True
     CSRF_TRUSTED_ORIGINS = ["http://localhost:8072", "http://localhost:3000"]
     DEBUG = True
 

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "dj-database-url==3.1.2",
     "django==6.0.7",
     "django-configurations==2.5.1",
-    "django-cors-headers==4.9.0",
     "django-lasuite[all]==0.0.27",
     "django-ninja==1.6.2",
     "django-redis==7.0.0",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -351,19 +351,6 @@ wheels = [
 ]
 
 [[package]]
-name = "django-cors-headers"
-version = "4.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asgiref" },
-    { name = "django" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/39/55822b15b7ec87410f34cd16ce04065ff390e50f9e29f31d6d116fc80456/django_cors_headers-4.9.0.tar.gz", hash = "sha256:fe5d7cb59fdc2c8c646ce84b727ac2bca8912a247e6e68e1fb507372178e59e8", size = 21458, upload-time = "2025-09-18T10:40:52.326Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/d8/19ed1e47badf477d17fb177c1c19b5a21da0fd2d9f093f23be3fb86c5fab/django_cors_headers-4.9.0-py3-none-any.whl", hash = "sha256:15c7f20727f90044dcee2216a9fd7303741a864865f0c3657e28b7056f61b449", size = 12809, upload-time = "2025-09-18T10:40:50.843Z" },
-]
-
-[[package]]
 name = "django-debug-toolbar"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -646,7 +633,6 @@ dependencies = [
     { name = "dj-database-url" },
     { name = "django" },
     { name = "django-configurations" },
-    { name = "django-cors-headers" },
     { name = "django-lasuite", extra = ["all"] },
     { name = "django-ninja" },
     { name = "django-redis" },
@@ -678,7 +664,6 @@ requires-dist = [
     { name = "dj-database-url", specifier = "==3.1.2" },
     { name = "django", specifier = "==6.0.7" },
     { name = "django-configurations", specifier = "==2.5.1" },
-    { name = "django-cors-headers", specifier = "==4.9.0" },
     { name = "django-lasuite", extras = ["all"], specifier = "==0.0.27" },
     { name = "django-ninja", specifier = "==1.6.2" },
     { name = "django-redis", specifier = "==7.0.0" },


### PR DESCRIPTION
## Purpose

As we are running a headless API server, we don't need to handle CORS.

## Proposal

- [x] remove `django-cors-headers` dependency
- [x] clean related settings
