### PR TITLE
Use a standard JWK key set serialization

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -162,7 +162,8 @@ jobs:
         run: uv sync --locked --all-extras --dev
 
       - name: Define required environment variables
-        run: ../../bin/local-env
+        run: |
+          cd ../.. && make create-env-local-files
 
       - name: Run tests
         run: uv run pytest -n 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 ### Changed
 
 - Remove `--app` flag in the container production command
+- Use standard JWK set serialization for the `TOKEN_EXCHANGE_JWT_SIGNING_KEYS`
+  setting
 
 ## [0.2.0] - 2026-07-29
 

--- a/bin/local-env
+++ b/bin/local-env
@@ -2,17 +2,27 @@
 
 echo -e "⚙️ Generating local environment variable files…"
 
-declare rsa_key
+declare keyset
+declare kid
 declare common_env_path=${GITHUB_ENV:-"env.d/development/common.local"}
-declare kid="d5b6a7fd-891d-40ab-833d-c2923b029e29"
 
-# Generate a RSA private key
-rsa_key=$(\
-  docker compose run --rm openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 | \
-  sed 's/$/\\n/' | \
-  tr -d "\n" \
+declare snippet='
+import json
+import sys
+from joserfc.jwk import KeySet
+keyset = KeySet.generate_key_set("RSA", 2048, count=2, parameters={"use": "sig"})
+sys.stdout.write(json.dumps(keyset.as_dict()) + "\n")
+sys.stdout.write(keyset.keys[0].kid)
+'
+
+# Generate a RSA private keys
+output=$(\
+  echo "${snippet}" | \
+  docker compose run --no-deps --rm -i menshen uv run python - | \
+  grep -v 🐳\
 )
+keyset=$(echo "${output}" | head -n 1)
+kid=$(echo "${output}" | tail -n 1)
 
-
-echo "TOKEN_EXCHANGE_JWT_SIGNING_KEYS={\"${kid}\": \"${rsa_key}\"}" >> ${common_env_path}
+echo "TOKEN_EXCHANGE_JWT_SIGNING_KEYS=${keyset}" >> ${common_env_path}
 echo "TOKEN_EXCHANGE_JWT_CURRENT_KID=${kid}" >> ${common_env_path}

--- a/compose.yml
+++ b/compose.yml
@@ -30,6 +30,7 @@ services:
     image: menshen:backend-development
     environment:
       - DJANGO_CONFIGURATION=Development
+      - HOME=/tmp
     env_file:
       - env.d/development/common
       - env.d/development/common.local

--- a/compose.yml
+++ b/compose.yml
@@ -168,10 +168,6 @@ services:
       menshen:
         condition: service_healthy
 
-  # Utils
-  openssl:
-    image: alpine/openssl:3.5.7
-
 networks:
   default: {}
   lasuite:

--- a/src/backend/token_exchange/services/token.py
+++ b/src/backend/token_exchange/services/token.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.utils import timezone
 from joserfc import jwt
 from joserfc.errors import ClaimError, InvalidKeyIdError
-from joserfc.jwk import KeySet, RSAKey
+from joserfc.jwk import KeySet
 from joserfc.jwt import Token
 
 from token_exchange.schemas import (
@@ -29,12 +29,7 @@ class TokenGenerator:
     @cache
     def _load_key_set(cls):
         """Load configured key set and init the class key_set attribute."""
-        cls.key_set = KeySet(
-            [
-                RSAKey.import_key(pem, {"use": "sig", "kid": kid})
-                for kid, pem in settings.TOKEN_EXCHANGE_JWT_SIGNING_KEYS.items()
-            ]
-        )
+        cls.key_set = KeySet.import_key_set(settings.TOKEN_EXCHANGE_JWT_SIGNING_KEYS)
         if cls.key_set is None or not len(cls.key_set.keys):
             raise ValueError("TOKEN_EXCHANGE_JWT_SIGNING_KEYS is empty.")
 

--- a/src/backend/token_exchange/tests/services/test_token.py
+++ b/src/backend/token_exchange/tests/services/test_token.py
@@ -27,7 +27,7 @@ def test_token_generator_generate_opaque_token():
 def test_token_generator_load_key_set_configuration_not_set(settings):
     """Test the signing keys importation from settings when it's not configured."""
     settings.TOKEN_EXCHANGE_JWT_SIGNING_KEYS = {}
-    with pytest.raises(ValueError, match="TOKEN_EXCHANGE_JWT_SIGNING_KEYS is empty."):
+    with pytest.raises(KeyError, match="keys"):
         TokenGenerator._load_key_set()
 
 


### PR DESCRIPTION
## Purpose

For now, we store our JWT signing keys in Django settings using a simple dictionnary. We can improve that by using a standard JWK set JSON serialization.

```json
{"keys": [
    {
        "kty":"EC",
        "crv":"P-256",
        "x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
        "y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
        "use":"enc",
        "kid":"1"
    },
    {
        "kty":"RSA",
        "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx...",
        "e":"AQAB",
        "alg":"RS256",
        "kid":"2011-04-29"
    }
]}
```

## Proposal

- [x] 🧑‍💻(project) set container HOME environment variable
- [x] 🔨(backend) use joserfc to generate a JWT signing key set
