### PR TITLE
👷(project) semver-pin docker-related Github Actions

### DIFF
--- a/.github/workflows/_docker-publish.yml
+++ b/.github/workflows/_docker-publish.yml
@@ -52,10 +52,10 @@ jobs:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to DockerHub
         if: ${{ inputs.should_push }}
@@ -66,13 +66,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ inputs.image_name }}
 
       - name: Build and push
         id: build-push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}


### PR DESCRIPTION
## Purpose

A code scanning result pointed a new security issue:

> action's hash pin has mismatched or missing version comment: points to commit 37fe63102785

Reference:
https://github.com/suitenumerique/menshen/security/code-scanning/39

## Proposal

To avoid discrepancies between the latest major series hash (_e.g._ `v4`) and pointed version hash (_e.g_. `v4.2.1`), we need to pin Github actions version comments using a complete semantic versioning pattern (i.e. `major.minor.patch`).
