### PR TITLE
🛂(backend) remove OIDC authentication backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 ### Changed
 
 - Remove `--app` flag in the container production command
+- Remove unused OIDC authentication backend
 
 ### Removed
 
-- clean unused `django-cors-headers` configured dependency
+- Clean unused `django-cors-headers` configured dependency
 
 ## [0.2.0] - 2026-07-29
 

--- a/src/backend/menshen/settings.py
+++ b/src/backend/menshen/settings.py
@@ -169,7 +169,6 @@ class Base(Configuration):
 
     AUTHENTICATION_BACKENDS = [
         "django.contrib.auth.backends.ModelBackend",
-        "lasuite.oidc_login.backends.OIDCAuthenticationBackend",
     ]
 
     # Django applications from the highest priority to the lowest


### PR DESCRIPTION
## Purpose

When trying to access the admin login page, Menshen's backend tries to load configured authentication backends (including LaSuite OIDC backend). As none as been configured, the admin login view returns a 500 HTTP code with the following log:

```
Setting OIDC_RP_CLIENT_ID not found
```

## Proposal

Menshen will only create and authorize local superuser/staff users to log in. Thus, LaSuite's OIDC authentication backend is not required and can be safely removed.
